### PR TITLE
Async actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: nbstripout
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.1
+    rev: v0.11.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/example_lab/example_modules/nodes/liquidhandler_1.node.info.yaml
+++ b/example_lab/example_modules/nodes/liquidhandler_1.node.info.yaml
@@ -18,31 +18,18 @@ capabilities:
   get_resources: false
   get_log: true
   admin_commands:
-  - unlock
+  - shutdown
   - reset
-  - pause
-  - cancel
+  - unlock
+  - resume
   - safety_stop
   - lock
-  - resume
-  - shutdown
+  - cancel
+  - pause
 commands: {}
 is_template: false
 config_defaults: {}
-actions:
-  run_command:
-    name: run_command
-    description: Run a command on the liquid handler.
-    args:
-      command:
-        name: command
-        description: ''
-        type: str
-        required: true
-        default: null
-    files: {}
-    results: {}
-    blocking: false
+actions: {}
 config:
   status_update_interval: null
   state_update_interval: null
@@ -50,7 +37,6 @@ config:
   host: 127.0.0.1
   port: 8000
   protocol: http
-  device_number: 0
 config_schema:
   $defs:
     EventClientConfig:
@@ -76,10 +62,7 @@ config_schema:
           title: Event Client Log Level
           type: integer
         source:
-          anyOf:
-          - $ref: '#/$defs/OwnershipInfo'
-          - type: 'null'
-          default: null
+          $ref: '#/$defs/OwnershipInfo'
           description: Information about the source of the event client.
           title: Source
         log_dir:
@@ -147,10 +130,24 @@ config_schema:
           default: null
           description: The ID of the lab that owns the object.
           title: Lab ID
+        step_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          description: The ID of the step that owns the object.
+          title: Step ID
+        workflow_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          description: The ID of the workflow that owns the object.
+          title: Workflow ID
       title: OwnershipInfo
       type: object
   additionalProperties: true
-  description: Configuration for the liquid handler node module.
+  description: Default Configuration for a MADSci Node that communicates over REST.
   properties:
     status_update_interval:
       anyOf:
@@ -188,9 +185,5 @@ config_schema:
       description: The protocol of the REST API, either 'http' or 'https'.
       title: Protocol
       type: string
-    device_number:
-      default: 0
-      title: Device Number
-      type: integer
-  title: LiquidHandlerConfig
+  title: RestNodeConfig
   type: object

--- a/example_lab/example_modules/nodes/liquidhandler_1.node.yaml
+++ b/example_lab/example_modules/nodes/liquidhandler_1.node.yaml
@@ -18,14 +18,14 @@ capabilities:
   get_resources: false
   get_log: true
   admin_commands:
-  - unlock
+  - shutdown
   - reset
-  - pause
-  - cancel
+  - unlock
+  - resume
   - safety_stop
   - lock
-  - resume
-  - shutdown
+  - cancel
+  - pause
 commands: {}
 is_template: false
 config_defaults: {}

--- a/example_lab/node_notebook.ipynb
+++ b/example_lab/node_notebook.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Automatting your Laboratory with MADSci Nodes\n",
+    "\n",
+    "This notebook aims to teach you how to automate and integrate all the devices, instruments, sensors, and robots in your self-driving lab using the MADSci Node standard.\n",
+    "\n",
+    "## Goals\n",
+    "\n",
+    "After completing this notebook, you should understand\n",
+    "\n",
+    "1. What we mean when we talk about a MADSci Node\n",
+    "2. The MADSci Node interface standard\n",
+    "3. How to integrate and automate a device using the MADSci Node standard\n",
+    "4. How to use the `RestNode` python class included in `madsci.node_module` to integrate a MADSci Node\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastapi.testclient import TestClient\n",
+    "from madsci.node_module.rest_node_module import RestNode\n",
+    "from rich import print"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ExampleNode(RestNode):\n",
+    "    \"\"\"Define an Example Node. It doesn't do anything yet, but it's a good starting point.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from madsci.common.types.node_types import NodeDefinition\n",
+    "\n",
+    "node_definition = NodeDefinition(\n",
+    "    node_name=\"example_node\",\n",
+    "    module_name=\"example_node_module\",\n",
+    "    description=\"An example node\",\n",
+    ")\n",
+    "example_node = ExampleNode(node_definition=node_definition)\n",
+    "example_node.start_node(testing=True)\n",
+    "test_client = TestClient(example_node.rest_api)\n",
+    "with test_client as request:\n",
+    "    response = request.get(\"/status\")\n",
+    "    print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections.abc import Generator\n",
+    "from typing import Any\n",
+    "from unittest.mock import patch\n",
+    "\n",
+    "from madsci.client.node.rest_node_client import RestNodeClient\n",
+    "\n",
+    "\n",
+    "def client(test_client: TestClient) -> Generator[RestNodeClient, None, None]:\n",
+    "    \"\"\"Fixture for DataClient patched to use TestClient\"\"\"\n",
+    "    with patch(\"madsci.client.node.rest_node_client.requests\") as mock_requests:\n",
+    "\n",
+    "        def post_no_timeout(*args: Any, **kwargs: Any) -> Any:\n",
+    "            kwargs.pop(\"timeout\", None)\n",
+    "            return test_client.post(*args, **kwargs)\n",
+    "\n",
+    "        mock_requests.post.side_effect = post_no_timeout\n",
+    "\n",
+    "        def get_no_timeout(*args: Any, **kwargs: Any) -> Any:\n",
+    "            kwargs.pop(\"timeout\", None)\n",
+    "            return test_client.get(*args, **kwargs)\n",
+    "\n",
+    "        mock_requests.get.side_effect = get_no_timeout\n",
+    "\n",
+    "        yield RestNodeClient(url=\"http://localhost:2000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with (\n",
+    "    test_client as request,\n",
+    "    patch(\"madsci.client.node.rest_node_client.requests\") as mock_requests,\n",
+    "):\n",
+    "\n",
+    "    def post_no_timeout(*args: Any, **kwargs: Any) -> Any:\n",
+    "        \"\"\"Patch post method to remove timeout argument\"\"\"\n",
+    "        kwargs.pop(\"timeout\", None)\n",
+    "        return request.post(*args, **kwargs)\n",
+    "\n",
+    "    mock_requests.post.side_effect = post_no_timeout\n",
+    "\n",
+    "    def get_no_timeout(*args: Any, **kwargs: Any) -> Any:\n",
+    "        \"\"\"Patch get method to remove timeout argument\"\"\"\n",
+    "        kwargs.pop(\"timeout\", None)\n",
+    "        return request.get(*args, **kwargs)\n",
+    "\n",
+    "    mock_requests.get.side_effect = get_no_timeout\n",
+    "\n",
+    "    rest_node_client = RestNodeClient(url=\"http://localhost:2000\")\n",
+    "    print(rest_node_client.get_status())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/madsci_client/madsci/client/event_client.py
+++ b/src/madsci_client/madsci/client/event_client.py
@@ -52,7 +52,8 @@ class EventClient:
             else:
                 # * No luck, name after EventClient
                 self.name = __name__
-        self.logger = logging.getLogger(self.name)
+        self.name = str(self.name)
+        self.logger = logging.getLogger()
         self.log_dir = Path(self.config.log_dir).expanduser()
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.logfile = self.log_dir / f"{self.name}.log"
@@ -80,9 +81,9 @@ class EventClient:
             for line in log.readlines():
                 try:
                     event = Event.model_validate_json(line)
-                    events[event.event_id] = event
                 except ValidationError:
-                    events.append(Event(event_type=EventType.UNKNOWN, event_data=line))
+                    event = Event(event_type=EventType.UNKNOWN, event_data=line)
+                events[event.event_id] = event
         return events
 
     def get_events(self, number: int = 100, level: int = -1) -> dict[str, Event]:

--- a/src/madsci_client/madsci/client/node/abstract_node_client.py
+++ b/src/madsci_client/madsci/client/node/abstract_node_client.py
@@ -1,6 +1,6 @@
 """Base node client implementation."""
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Optional
 
 from madsci.common.types.action_types import (
     ActionRequest,
@@ -32,7 +32,12 @@ class AbstractNodeClient:
         """Initialize the client."""
         self.url = url
 
-    def send_action(self, action_request: ActionRequest) -> ActionResult:
+    def send_action(
+        self,
+        action_request: ActionRequest,
+        await_result: bool = True,
+        timeout: Optional[float] = None,
+    ) -> ActionResult:
         """Perform an action on the node."""
         raise NotImplementedError("send_action not implemented by this client")
 
@@ -45,6 +50,14 @@ class AbstractNodeClient:
     def get_action_result(self, action_id: str) -> ActionResult:
         """Get the status of an action on the node."""
         raise NotImplementedError("get_action_result is not implemented by this client")
+
+    def await_action_result(
+        self, action_id: str, timeout: Optional[float] = None
+    ) -> ActionResult:
+        """Wait for an action to complete and return the result. Optionally, specify a timeout in seconds."""
+        raise NotImplementedError(
+            "await_action_result is not implemented by this client"
+        )
 
     def get_status(self) -> NodeStatus:
         """Get the status of the node."""

--- a/src/madsci_client/madsci/client/node/rest_node_client.py
+++ b/src/madsci_client/madsci/client/node/rest_node_client.py
@@ -87,9 +87,11 @@ class RestNodeClient(AbstractNodeClient):
             # * Ensure files are closed
             for file in files:
                 file[1][1].close()
-        if not rest_response.ok:
-            self.logger.log_error(f"{rest_response.status_code}: {rest_response.text}")
+        try:
             rest_response.raise_for_status()
+        except requests.HTTPError as e:
+            self.logger.log_error(f"{rest_response.status_code}: {rest_response.text}")
+            raise e
         if "x-madsci-status" in rest_response.headers:
             response = process_file_response(rest_response)
         else:
@@ -114,8 +116,7 @@ class RestNodeClient(AbstractNodeClient):
             f"{self.url}/action/{action_id}",
             timeout=10,
         )
-        if not rest_response.ok:
-            rest_response.raise_for_status()
+        rest_response.raise_for_status()
         if "x-madsci-status" in rest_response.headers:
             response = process_file_response(rest_response)
         else:
@@ -143,22 +144,19 @@ class RestNodeClient(AbstractNodeClient):
     def get_status(self) -> NodeStatus:
         """Get the status of the node."""
         response = requests.get(f"{self.url}/status", timeout=10)
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return NodeStatus.model_validate(response.json())
 
     def get_state(self) -> dict[str, Any]:
         """Get the state of the node."""
         response = requests.get(f"{self.url}/state", timeout=10)
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return response.json()
 
     def get_info(self) -> NodeInfo:
         """Get information about the node."""
         response = requests.get(f"{self.url}/info", timeout=10)
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return NodeInfo.model_validate(response.json())
 
     def set_config(self, new_config: dict[str, Any]) -> NodeSetConfigResponse:
@@ -168,15 +166,13 @@ class RestNodeClient(AbstractNodeClient):
             json=new_config,
             timeout=60,
         )
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return NodeSetConfigResponse.model_validate(response.json())
 
     def send_admin_command(self, admin_command: AdminCommands) -> bool:
         """Perform an administrative command on the node."""
         response = requests.post(f"{self.url}/admin/{admin_command}", timeout=10)
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return AdminCommandResponse.model_validate(response.json())
 
     def get_resources(self) -> dict[str, ResourceDefinition]:
@@ -189,8 +185,7 @@ class RestNodeClient(AbstractNodeClient):
     def get_log(self) -> dict[str, Event]:
         """Get the log from the node"""
         response = requests.get(f"{self.url}/log", timeout=10)
-        if not response.ok:
-            response.raise_for_status()
+        response.raise_for_status()
         return response.json()
 
 

--- a/src/madsci_client/madsci/client/node/rest_node_client.py
+++ b/src/madsci_client/madsci/client/node/rest_node_client.py
@@ -127,7 +127,7 @@ class RestNodeClient(AbstractNodeClient):
     ) -> ActionResult:
         """Wait for an action to complete and return the result. Optionally, specify a timeout in seconds."""
         start_time = time.time()
-        interval = 0.1
+        interval = 0.25
         while True:
             if timeout is not None and time.time() - start_time > timeout:
                 raise TimeoutError("Timed out waiting for action to complete.")
@@ -135,7 +135,7 @@ class RestNodeClient(AbstractNodeClient):
             if not response.status.is_terminal:
                 time.sleep(interval)
                 interval = (
-                    interval * 2 if interval < 10 else 10
+                    interval * 1.5 if interval < 10 else 10
                 )  # * Capped Exponential backoff
                 continue
             return response

--- a/src/madsci_client/madsci/client/workcell_client.py
+++ b/src/madsci_client/madsci/client/workcell_client.py
@@ -3,71 +3,107 @@
 import json
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import requests
 from madsci.common.exceptions import WorkflowFailedError
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.location_types import Location
+from madsci.common.types.node_types import Node
 from madsci.common.types.workcell_types import WorkcellState
 from madsci.common.types.workflow_types import (
     Workflow,
     WorkflowDefinition,
     WorkflowStatus,
 )
+from madsci.common.utils import PathLike
 from madsci.workcell_manager.workflow_utils import insert_parameter_values
 
 
 class WorkcellClient:
-    """a client for running workflows"""
+    """A client for interacting with the Workcell Manager to perform various actions."""
 
     def __init__(
         self,
         workcell_manager_url: str,
         working_directory: str = "~/.MADsci/temp",
         ownership_info: Optional[OwnershipInfo] = None,
-    ) -> "WorkcellClient":
-        """initialize the client"""
+    ) -> None:
+        """
+        Initialize the WorkcellClient.
+
+        Parameters
+        ----------
+        workcell_manager_url : str
+            The base URL of the Workcell Manager.
+        working_directory : str, optional
+            The directory for temporary workflow files, by default "~/.MADsci/temp".
+        ownership_info : Optional[OwnershipInfo], optional
+            Ownership information for workflows, by default None.
+        """
         self.url = workcell_manager_url
         self.working_directory = Path(working_directory).expanduser()
         self.ownership_info = ownership_info
 
     def query_workflow(self, workflow_id: str) -> Optional[Workflow]:
-        """Checks on a workflow run using the id given
+        """
+        Check the status of a workflow using its ID.
 
         Parameters
         ----------
-
         workflow_id : str
-           The id returned by the start_workflow function for this run
+            The ID of the workflow to query.
 
         Returns
         -------
-
-        response: Dict
-           The JSON portion of the response from the server"""
-
+        Optional[Workflow]
+            The workflow object if found, otherwise None.
+        """
         url = f"{self.url}/workflow/{workflow_id}"
         response = requests.get(url, timeout=10)
 
-        if response.ok:
-            return Workflow(**response.json())
         response.raise_for_status()
-        return None
+        return Workflow(**response.json())
 
     def submit_workflow(
         self,
-        workflow: str,
-        parameters: dict,
+        workflow: Union[PathLike, WorkflowDefinition],
+        parameters: Optional[dict[str, Any]] = None,
         validate_only: bool = False,
         blocking: bool = True,
         raise_on_failed: bool = True,
         raise_on_cancelled: bool = True,
     ) -> Workflow:
-        """Send a workflow to the workcell manager"""
-        workflow = WorkflowDefinition.from_yaml(workflow)
-        WorkflowDefinition.model_validate(workflow)
-        insert_parameter_values(workflow=workflow, parameters=parameters)
+        """
+        Submit a workflow to the Workcell Manager.
+
+        Parameters
+        ----------
+        workflow: Union[PathLike, WorkflowDefinition],
+            Either a WorkflowDefinition or a path to a YAML file of one.
+        parameters: Optional[dict[str, Any]] = None,
+            Parameters to be inserted into the workflow.
+        validate_only : bool, optional
+            If True, only validate the workflow without submitting, by default False.
+        blocking : bool, optional
+            If True, wait for the workflow to complete, by default True.
+        raise_on_failed : bool, optional
+            If True, raise an exception if the workflow fails, by default True.
+        raise_on_cancelled : bool, optional
+            If True, raise an exception if the workflow is cancelled, by default True.
+
+        Returns
+        -------
+        Workflow
+            The submitted workflow object.
+        """
+        if isinstance(workflow, (Path, str)):
+            workflow = WorkflowDefinition.from_yaml(workflow)
+        else:
+            workflow = WorkflowDefinition.model_validate(workflow)
+        insert_parameter_values(
+            workflow=workflow, parameters=parameters if parameters else {}
+        )
         files = self._extract_files_from_workflow(workflow)
         url = self.url + "/workflow"
         response = requests.post(
@@ -76,7 +112,7 @@ class WorkcellClient:
                 "workflow": workflow.model_dump_json(),
                 "parameters": json.dumps(parameters),
                 "validate_only": validate_only,
-                "ownership_info": self.ownership_info.model_dump(mode="json")
+                "ownership_info": self.ownership_info.model_dump_json()
                 if self.ownership_info
                 else None,
             },
@@ -104,9 +140,19 @@ class WorkcellClient:
 
     def _extract_files_from_workflow(
         self, workflow: WorkflowDefinition
-    ) -> dict[str, Any]:
+    ) -> dict[str, Path]:
         """
-        Returns a dictionary of files from a workflow
+        Extract file paths from a workflow definition.
+
+        Parameters
+        ----------
+        workflow : WorkflowDefinition
+            The workflow definition object.
+
+        Returns
+        -------
+        dict[str, Path]
+            A dictionary mapping unique file names to their paths.
         """
         files = {}
         for step in workflow.steps:
@@ -122,9 +168,23 @@ class WorkcellClient:
         return files
 
     def submit_workflow_sequence(
-        self, workflows: list[str], parameters: list[dict[str:Any]]
+        self, workflows: list[str], parameters: list[dict[str, Any]]
     ) -> list[Workflow]:
-        """Submit a list of workflows to run in a specific order"""
+        """
+        Submit a sequence of workflows to run in order.
+
+        Parameters
+        ----------
+        workflows : list[str]
+            A list of workflow definitions in YAML format.
+        parameters : list[dict[str, Any]]
+            A list of parameter dictionaries for each workflow.
+
+        Returns
+        -------
+        list[Workflow]
+            A list of submitted workflow objects.
+        """
         wfs = []
         for i in range(len(workflows)):
             wf = self.submit_workflow(workflows[i], parameters[i], blocking=True)
@@ -132,9 +192,23 @@ class WorkcellClient:
         return wfs
 
     def submit_workflow_batch(
-        self, workflows: list[str], parameters: list[dict[str:Any]]
+        self, workflows: list[str], parameters: list[dict[str, Any]]
     ) -> list[Workflow]:
-        """Submit a batch of workflows to run in no particular order"""
+        """
+        Submit a batch of workflows to run concurrently.
+
+        Parameters
+        ----------
+        workflows : list[str]
+            A list of workflow definitions in YAML format.
+        parameters : list[dict[str, Any]]
+            A list of parameter dictionaries for each workflow.
+
+        Returns
+        -------
+        list[Workflow]
+            A list of completed workflow objects.
+        """
         id_list = []
         for i in range(len(workflows)):
             response = self.submit_workflow(workflows[i], parameters[i], blocking=False)
@@ -151,7 +225,21 @@ class WorkcellClient:
         return wfs
 
     def retry_workflow(self, workflow_id: str, index: int = -1) -> dict:
-        """rerun an exisiting wf using the same wf id"""
+        """
+        Retry a workflow from a specific step.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to retry.
+        index : int, optional
+            The step index to retry from, by default -1 (retry the entire workflow).
+
+        Returns
+        -------
+        dict
+            The response from the Workcell Manager.
+        """
         url = f"{self.url}/workflow/{workflow_id}/retry"
         response = requests.post(
             url,
@@ -170,7 +258,25 @@ class WorkcellClient:
         raise_on_failed: bool = True,
         raise_on_cancelled: bool = True,
     ) -> Workflow:
-        """resubmit an existing workflows as a new workflow with a new id"""
+        """
+        Resubmit a workflow as a new workflow with a new ID.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to resubmit.
+        blocking : bool, optional
+            If True, wait for the workflow to complete, by default True.
+        raise_on_failed : bool, optional
+            If True, raise an exception if the workflow fails, by default True.
+        raise_on_cancelled : bool, optional
+            If True, raise an exception if the workflow is cancelled, by default True.
+
+        Returns
+        -------
+        Workflow
+            The resubmitted workflow object.
+        """
         url = f"{self.url}/workflow/{workflow_id}/resubmit"
         response = requests.get(url, timeout=10)
         new_wf = Workflow(**response.json())
@@ -188,7 +294,23 @@ class WorkcellClient:
         raise_on_failed: bool = True,
         raise_on_cancelled: bool = True,
     ) -> Workflow:
-        """await a workflows completion"""
+        """
+        Wait for a workflow to complete.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to wait for.
+        raise_on_failed : bool, optional
+            If True, raise an exception if the workflow fails, by default True.
+        raise_on_cancelled : bool, optional
+            If True, raise an exception if the workflow is cancelled, by default True.
+
+        Returns
+        -------
+        Workflow
+            The completed workflow object.
+        """
         prior_status = None
         prior_index = None
         while True:
@@ -227,15 +349,34 @@ class WorkcellClient:
             )
         return wf
 
-    def get_nodes(self) -> dict:
-        """get all nodes in the workcell"""
+    def get_nodes(self) -> dict[str, Node]:
+        """
+        Get all nodes in the workcell.
+
+        Returns
+        -------
+        dict[str, Node]
+            A dictionary of node names and their details.
+        """
         url = f"{self.url}/nodes"
         response = requests.get(url, timeout=10)
         return response.json()
 
-    def get_node(self, node_name: str) -> dict:
-        """get a single node from a workcell"""
-        url = f"{self.url}/nodes/{node_name}"
+    def get_node(self, node_name: str) -> Node:
+        """
+        Get details of a specific node.
+
+        Parameters
+        ----------
+        node_name : str
+            The name of the node.
+
+        Returns
+        -------
+        Node
+            The node details.
+        """
+        url = f"{self.url}/node/{node_name}"
         response = requests.get(url, timeout=10)
         return response.json()
 
@@ -245,9 +386,27 @@ class WorkcellClient:
         node_url: str,
         node_description: str = "A Node",
         permanent: bool = False,
-    ) -> dict:
-        """add a node to a workcell"""
-        url = f"{self.url}/nodes/add_node"
+    ) -> Node:
+        """
+        Add a node to the workcell.
+
+        Parameters
+        ----------
+        node_name : str
+            The name of the node.
+        node_url : str
+            The URL of the node.
+        node_description : str, optional
+            A description of the node, by default "A Node".
+        permanent : bool, optional
+            If True, add the node permanently, by default False.
+
+        Returns
+        -------
+        Node
+            The added node details.
+        """
+        url = f"{self.url}/node"
         response = requests.post(
             url,
             params={
@@ -260,69 +419,163 @@ class WorkcellClient:
         )
         return response.json()
 
-    def get_workflows(self) -> dict:
-        """get all workflows from a workcell manager"""
+    def get_workflows(self) -> dict[str, Workflow]:
+        """
+        Get all workflows from the Workcell Manager.
+
+        Returns
+        -------
+        dict[str, Workflow]
+            A dictionary of workflow IDs and their details.
+        """
         url = f"{self.url}/workflows"
         response = requests.get(url, timeout=100)
-        return response.json()
+        response.raise_for_status()
+        workflow_dict = response.json()
+        if not isinstance(workflow_dict, dict):
+            raise ValueError(
+                f"Expected a dictionary of workflows, but got {type(workflow_dict)}."
+            )
+        return {
+            key: Workflow.model_validate(value) for key, value in workflow_dict.items()
+        }
 
-    def get_workflow_queue(self) -> dict:
-        """get the workflow queue from the workcell"""
+    def get_workflow_queue(self) -> list[Workflow]:
+        """
+        Get the workflow queue from the workcell.
+
+        Returns
+        -------
+        list[Workflow]
+            A list of queued workflows.
+        """
         url = f"{self.url}/workflows/queue"
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         return [Workflow.model_validate(wf) for wf in response.json()]
 
-    def get_workcell_state(self) -> dict:
-        """Get the full state of the workcell"""
+    def get_workcell_state(self) -> WorkcellState:
+        """
+        Get the full state of the workcell.
+
+        Returns
+        -------
+        WorkcellState
+            The current state of the workcell.
+        """
         url = f"{self.url}/state"
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         return WorkcellState.model_validate(response.json())
 
-    def pause_workflow(self, workflow_id: str) -> dict:
-        """pause a workflow"""
+    def pause_workflow(self, workflow_id: str) -> Workflow:
+        """
+        Pause a workflow.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to pause.
+
+        Returns
+        -------
+        Workflow
+            The paused workflow object.
+        """
         url = f"{self.url}/workflow/{workflow_id}/pause"
-        response = requests.get(url, timeout=10)
+        response = requests.post(url, timeout=10)
         response.raise_for_status()
         return Workflow.model_validate(response.json())
 
-    def resume_workflow(self, workflow_id: str) -> dict:
-        """resume a workflow"""
+    def resume_workflow(self, workflow_id: str) -> Workflow:
+        """
+        Resume a paused workflow.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to resume.
+
+        Returns
+        -------
+        Workflow
+            The resumed workflow object.
+        """
         url = f"{self.url}/workflow/{workflow_id}/resume"
-        response = requests.get(url, timeout=10)
+        response = requests.post(url, timeout=10)
         response.raise_for_status()
         return Workflow.model_validate(response.json())
 
-    def cancel_workflow(self, workflow_id: str) -> dict:
-        """cancel a workflow"""
+    def cancel_workflow(self, workflow_id: str) -> Workflow:
+        """
+        Cancel a workflow.
+
+        Parameters
+        ----------
+        workflow_id : str
+            The ID of the workflow to cancel.
+
+        Returns
+        -------
+        Workflow
+            The cancelled workflow object.
+        """
         url = f"{self.url}/workflow/{workflow_id}/cancel"
-        response = requests.get(url, timeout=10)
+        response = requests.post(url, timeout=10)
         response.raise_for_status()
         return Workflow.model_validate(response.json())
 
     def get_locations(self) -> list[Location]:
-        """get all locations in the workcell"""
+        """
+        Get all locations in the workcell.
+
+        Returns
+        -------
+        list[Location]
+            A list of locations.
+        """
         url = f"{self.url}/locations"
         response = requests.get(url, timeout=10)
         response.raise_for_status()
-        return [Location.model_validate(loc) for loc in response.json()]
+        return [Location.model_validate(loc) for loc in response.json().values()]
 
     def get_location(self, location_id: str) -> Location:
-        """get a single location from a workcell"""
+        """
+        Get details of a specific location.
+
+        Parameters
+        ----------
+        location_id : str
+            The ID of the location.
+
+        Returns
+        -------
+        Location
+            The location details.
+        """
         url = f"{self.url}/location/{location_id}"
         response = requests.get(url, timeout=10)
         response.raise_for_status()
         return Location.model_validate(response.json())
 
     def add_location(self, location: Location) -> Location:
-        """add a location to a workcell"""
+        """
+        Add a location to the workcell.
+
+        Parameters
+        ----------
+        location : Location
+            The location object to add.
+
+        Returns
+        -------
+        Location
+            The added location details.
+        """
         url = f"{self.url}/location"
         response = requests.post(
             url,
-            json={
-                "location": location.model_dump(mode="json"),
-            },
+            json=location.model_dump(mode="json"),
             timeout=10,
         )
         response.raise_for_status()
@@ -331,7 +584,21 @@ class WorkcellClient:
     def attach_resource_to_location(
         self, location_id: str, resource_id: str
     ) -> Location:
-        """Attach a resource container to a location"""
+        """
+        Attach a resource container to a location.
+
+        Parameters
+        ----------
+        location_id : str
+            The ID of the location.
+        resource_id : str
+            The ID of the resource to attach.
+
+        Returns
+        -------
+        Location
+            The updated location details.
+        """
         url = f"{self.url}/location/{location_id}/attach_resource"
         response = requests.post(
             url,
@@ -343,9 +610,20 @@ class WorkcellClient:
         response.raise_for_status()
         return Location.model_validate(response.json())
 
-    def delete_location(self, location_id: str) -> dict:
-        """delete a location from a workcell"""
+    def delete_location(self, location_id: str) -> None:
+        """
+        Delete a location from the workcell.
+
+        Parameters
+        ----------
+        location_id : str
+            The ID of the location to delete.
+
+        Returns
+        -------
+        dict
+            A dictionary indicating the deletion status.
+        """
         url = f"{self.url}/location/{location_id}"
         response = requests.delete(url, timeout=10)
         response.raise_for_status()
-        return response.json()

--- a/src/madsci_client/tests/test_workcell_client.py
+++ b/src/madsci_client/tests/test_workcell_client.py
@@ -1,0 +1,180 @@
+"""Unit tests for WorkcellClient."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from madsci.client.workcell_client import WorkcellClient
+from madsci.common.types.base_types import new_ulid_str
+from madsci.common.types.location_types import Location, LocationDefinition
+from madsci.common.types.workcell_types import WorkcellDefinition, WorkcellState
+from madsci.common.types.workflow_types import WorkflowStatus
+from madsci.workcell_manager.workcell_server import (
+    WorkflowDefinition,
+    create_workcell_server,
+)
+from pytest_mock_resources import RedisConfig, create_redis_fixture
+from redis import Redis
+from requests import Response
+
+
+# Create a Redis server fixture for testing
+@pytest.fixture(scope="session")
+def pmr_redis_config() -> RedisConfig:
+    """Configure the Redis server."""
+    return RedisConfig(image="redis:7.4")
+
+
+redis_server = create_redis_fixture()
+
+
+@pytest.fixture
+def workcell() -> WorkcellDefinition:
+    """Fixture for creating a WorkcellDefinition."""
+    return WorkcellDefinition(
+        workcell_name="Test Workcell",
+        locations=[
+            LocationDefinition(location_name="test_location"),
+        ],
+    )
+
+
+@pytest.fixture
+def test_client(
+    workcell: WorkcellDefinition, redis_server: Redis
+) -> Generator[TestClient, None, None]:
+    """Workcell Server Test Client Fixture."""
+    app = create_workcell_server(workcell, redis_server, start_engine=False)
+    client = TestClient(app)
+    with client:
+        yield client
+
+
+@pytest.fixture
+def client(test_client: TestClient) -> Generator[WorkcellClient, None, None]:
+    """Fixture for WorkcellClient patched to use TestClient."""
+    with patch("madsci.client.workcell_client.requests") as mock_requests:
+
+        def post_no_timeout(*args: Any, **kwargs: Any) -> Response:
+            kwargs.pop("timeout", None)
+            return test_client.post(*args, **kwargs)
+
+        mock_requests.post.side_effect = post_no_timeout
+
+        def get_no_timeout(*args: Any, **kwargs: Any) -> Response:
+            kwargs.pop("timeout", None)
+            return test_client.get(*args, **kwargs)
+
+        mock_requests.get.side_effect = get_no_timeout
+
+        def delete_no_timeout(*args: Any, **kwargs: Any) -> Response:
+            kwargs.pop("timeout", None)
+            return test_client.delete(*args, **kwargs)
+
+        mock_requests.delete.side_effect = delete_no_timeout
+
+        yield WorkcellClient(workcell_manager_url="http://testserver")
+
+
+def test_get_nodes(client: WorkcellClient) -> None:
+    """Test retrieving nodes from the workcell."""
+    response = client.add_node("node1", "http://node1/")
+    assert response["node_url"] == "http://node1/"
+    nodes = client.get_nodes()
+    assert "node1" in nodes
+    assert nodes["node1"]["node_url"] == "http://node1/"
+
+
+def test_get_node(client: WorkcellClient) -> None:
+    """Test retrieving a specific node."""
+    client.add_node("node1", "http://node1/")
+    node = client.get_node("node1")
+    assert node["node_url"] == "http://node1/"
+
+
+def test_add_node(client: WorkcellClient) -> None:
+    """Test adding a node to the workcell."""
+    node = client.add_node("node1", "http://node1/")
+    assert node["node_url"] == "http://node1/"
+
+
+def test_get_workflows(client: WorkcellClient) -> None:
+    """Test retrieving workflows."""
+    workflows = client.get_workflows()
+    assert isinstance(workflows, dict)
+
+
+def test_get_workflow_queue(client: WorkcellClient) -> None:
+    """Test retrieving the workflow queue."""
+    queue = client.get_workflow_queue()
+    assert isinstance(queue, list)
+
+
+def test_get_workcell_state(client: WorkcellClient) -> None:
+    """Test retrieving the workcell state."""
+    state = client.get_workcell_state()
+    assert isinstance(state, WorkcellState)
+
+
+def test_pause_workflow(client: WorkcellClient) -> None:
+    """Test pausing a workflow."""
+    workflow = client.submit_workflow(
+        WorkflowDefinition(name="Test Workflow"), {}, blocking=False
+    )
+    paused_workflow = client.pause_workflow(workflow.workflow_id)
+    assert paused_workflow.paused is True
+
+
+def test_resume_workflow(client: WorkcellClient) -> None:
+    """Test resuming a workflow."""
+    workflow = client.submit_workflow(
+        WorkflowDefinition(name="Test Workflow"), {}, blocking=False
+    )
+    client.pause_workflow(workflow.workflow_id)
+    resumed_workflow = client.resume_workflow(workflow.workflow_id)
+    assert resumed_workflow.paused is False
+
+
+def test_cancel_workflow(client: WorkcellClient) -> None:
+    """Test canceling a workflow."""
+    workflow = client.submit_workflow(
+        WorkflowDefinition(name="Test Workflow"), {}, blocking=False
+    )
+    canceled_workflow = client.cancel_workflow(workflow.workflow_id)
+    assert canceled_workflow.status == WorkflowStatus.CANCELLED
+
+
+def test_get_locations(client: WorkcellClient) -> None:
+    """Test retrieving locations."""
+    locations = client.get_locations()
+    assert isinstance(locations, list)
+    assert len(locations) == 1
+    assert locations[0].location_name == "test_location"
+
+
+def test_get_location(client: WorkcellClient) -> None:
+    """Test retrieving a specific location."""
+    location_id = client.get_locations()[0].location_id
+    fetched_location = client.get_location(location_id)
+    assert fetched_location.location_id == location_id
+
+
+def test_add_location(client: WorkcellClient) -> None:
+    """Test adding a location."""
+    location = Location(location_name="test_location2")
+    added_location = client.add_location(location)
+    assert added_location.location_id == location.location_id
+    assert added_location.location_name == location.location_name
+
+
+def test_attach_resource_to_location(client: WorkcellClient) -> None:
+    """Test attaching a resource to a location."""
+    location = Location(location_name="test_location3")
+    client.add_location(location)
+    mock_resource_id = new_ulid_str()
+    updated_location = client.attach_resource_to_location(
+        location.location_id, mock_resource_id
+    )
+    assert updated_location.resource_id == mock_resource_id

--- a/src/madsci_common/madsci/common/types/action_types.py
+++ b/src/madsci_common/madsci/common/types/action_types.py
@@ -23,6 +23,17 @@ class ActionStatus(str, Enum):
     PAUSED = "paused"
     UNKNOWN = "unknown"
 
+    @property
+    def is_terminal(self) -> bool:
+        """Check if the status is terminal"""
+        return self in [
+            ActionStatus.SUCCEEDED,
+            ActionStatus.FAILED,
+            ActionStatus.CANCELLED,
+            ActionStatus.UNKNOWN,
+            ActionStatus.NOT_READY,
+        ]
+
 
 class ActionRequest(BaseModel):
     """Request to perform an action on a node"""

--- a/src/madsci_common/madsci/common/types/action_types.py
+++ b/src/madsci_common/madsci/common/types/action_types.py
@@ -315,6 +315,11 @@ class ActionDefinition(BaseModel):
         description="Whether the action is blocking.",
         default=False,
     )
+    asynchronous: bool = Field(
+        title="Asynchronous",
+        description="Whether the action is asynchronous, and will return a 'running' status immediately rather than waiting for the action to complete before returning. This should be used for long-running actions (e.g. actions that take more than a few seconds to complete).",
+        default=True,
+    )
 
     @field_validator("args", mode="after")
     @classmethod

--- a/src/madsci_common/madsci/common/types/action_types.py
+++ b/src/madsci_common/madsci/common/types/action_types.py
@@ -382,7 +382,7 @@ class ActionArgumentDefinition(BaseModel):
         title="Argument Description",
         description="A description of the argument.",
     )
-    type: str = Field(
+    argument_type: str = Field(
         title="Argument Type", description="Any type information about the argument"
     )
     required: bool = Field(

--- a/src/madsci_common/madsci/common/types/action_types.py
+++ b/src/madsci_common/madsci/common/types/action_types.py
@@ -30,7 +30,6 @@ class ActionStatus(str, Enum):
             ActionStatus.SUCCEEDED,
             ActionStatus.FAILED,
             ActionStatus.CANCELLED,
-            ActionStatus.UNKNOWN,
             ActionStatus.NOT_READY,
         ]
 

--- a/src/madsci_common/madsci/common/types/auth_types.py
+++ b/src/madsci_common/madsci/common/types/auth_types.py
@@ -71,6 +71,9 @@ class OwnershipInfo(BaseModel):
         "project_id",
         "node_id",
         "workcell_id",
+        "step_id",
+        "lab_id",
+        "workflow_id",
         mode="after",
     )(ulid_validator)
 

--- a/src/madsci_common/madsci/common/types/auth_types.py
+++ b/src/madsci_common/madsci/common/types/auth_types.py
@@ -53,6 +53,16 @@ class OwnershipInfo(BaseModel):
         description="The ID of the lab that owns the object.",
         default=None,
     )
+    step_id: Optional[str] = Field(
+        title="Step ID",
+        description="The ID of the step that owns the object.",
+        default=None,
+    )
+    workflow_id: Optional[str] = Field(
+        title="Workflow ID",
+        description="The ID of the workflow that owns the object.",
+        default=None,
+    )
 
     is_ulid = field_validator(
         "user_id",

--- a/src/madsci_common/madsci/common/types/condition_types.py
+++ b/src/madsci_common/madsci/common/types/condition_types.py
@@ -35,12 +35,11 @@ class ResourceInLocationCondition(Condition):
     condition_type: Literal[ConditionTypeEnum.RESOURCE_PRESENT] = Field(
         title="Condition Type",
         description="The type of condition to check",
-        const=ConditionTypeEnum.RESOURCE_PRESENT,
+        default=ConditionTypeEnum.RESOURCE_PRESENT,
     )
-    location: Optional[str] = Field(
+    location: str = Field(
         title="Location",
         description="The name or ID of the location to check for a resource in",
-        default=None,
     )
     key: Optional[Union[str, int, GridIndex, GridIndex2D, GridIndex3D]] = Field(
         title="Key",
@@ -55,12 +54,11 @@ class NoResourceInLocationCondition(Condition):
     condition_type: Literal[ConditionTypeEnum.NO_RESOURCE_PRESENT] = Field(
         title="Condition Type",
         description="The type of condition to check",
-        const=ConditionTypeEnum.NO_RESOURCE_PRESENT,
+        default=ConditionTypeEnum.NO_RESOURCE_PRESENT,
     )
-    location: Optional[str] = Field(
+    location: str = Field(
         title="Location",
         description="The name or ID of the location to check for a resource in",
-        default=None,
     )
     key: Optional[Union[str, int, GridIndex, GridIndex2D, GridIndex3D]] = Field(
         title="Key",

--- a/src/madsci_common/madsci/common/types/event_types.py
+++ b/src/madsci_common/madsci/common/types/event_types.py
@@ -82,10 +82,10 @@ class EventClientConfig(BaseModel):
         description="The log level of the event client.",
         default=EventLogLevel.INFO,
     )
-    source: Optional[OwnershipInfo] = Field(
+    source: OwnershipInfo = Field(
         title="Source",
         description="Information about the source of the event client.",
-        default=None,
+        default_factory=OwnershipInfo,
     )
     log_dir: PathLike = Field(
         title="Log Directory",

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -1,10 +1,11 @@
 """Location types for MADSci."""
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.base_types import BaseModel, new_ulid_str
+from madsci.common.types.resource_types import ResourceDataModels
 from madsci.common.validators import ulid_validator
 from pydantic import Field
 from pydantic.functional_validators import field_validator
@@ -32,7 +33,7 @@ class Location(BaseModel):
         description="A dictionary of different representations of the location. Allows creating an association between a specific key (like a node name or id) and a relevant representation of the location (like joint angles, a specific actuator, etc).",
         default={},
     )
-    resource: Optional[Any] = Field(
+    resource: Optional[Union[ResourceDataModels, str]] = Field(
         title="Resource",
         description="The Resource associated with the location",
         default=None,

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -1,18 +1,18 @@
 """Location types for MADSci."""
 
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.base_types import BaseModel, new_ulid_str
-from madsci.common.types.resource_types import ResourceDataModels
+from madsci.common.types.resource_types.definitions import ResourceDefinitions
 from madsci.common.validators import ulid_validator
 from pydantic import Field
 from pydantic.functional_validators import field_validator
 
 
-class Location(BaseModel):
-    """A location in the lab."""
+class LocationDefinition(BaseModel):
+    """The Definition of a Workcell Location."""
 
     location_name: str = Field(
         title="Location Name",
@@ -33,11 +33,23 @@ class Location(BaseModel):
         description="A dictionary of different representations of the location. Allows creating an association between a specific key (like a node name or id) and a relevant representation of the location (like joint angles, a specific actuator, etc).",
         default={},
     )
-    resource: Optional[Union[ResourceDataModels, str]] = Field(
+    resource_definition: Optional[ResourceDefinitions] = Field(
         title="Resource",
-        description="The Resource associated with the location",
+        description="Definition of the Resource to be associated with this location (if any) on location initialization.",
         default=None,
     )
+    resource_id: Optional[str] = Field(
+        title="Resource ID",
+        description="The ID of an existing Resource associated with the location, if any. If not provided, a new Resource will be created based on the resource_definition, if one is provided. If not, no Resource will be associated with the location.",
+        default=None,
+    )
+
+    is_ulid = field_validator("location_id")(ulid_validator)
+
+
+class Location(LocationDefinition):
+    """A location in the lab."""
+
     reservation: Optional["LocationReservation"] = Field(
         title="Location Reservation",
         description="The reservation for the location.",

--- a/src/madsci_common/madsci/common/types/resource_types/definitions.py
+++ b/src/madsci_common/madsci/common/types/resource_types/definitions.py
@@ -78,6 +78,17 @@ class ResourceDefinition(BaseModel, table=False):
     )
     is_ulid = field_validator("resource_id")(ulid_validator)
 
+    @classmethod
+    def discriminate(cls, resource: dict) -> "ResourceDefinition":
+        """Discriminate the resource definition based on its base type."""
+        from madsci.common.types.resource_types import RESOURCE_TYPE_MAP
+
+        if isinstance(resource, dict):
+            resource_type = resource.get("base_type")
+        else:
+            resource_type = resource.base_type
+        return RESOURCE_TYPE_MAP[resource_type]["definition"].model_validate(resource)
+
 
 class AssetResourceDefinition(ResourceDefinition, table=False):
     """Definition for an asset resource."""

--- a/src/madsci_common/madsci/common/types/step_types.py
+++ b/src/madsci_common/madsci/common/types/step_types.py
@@ -67,10 +67,15 @@ class Step(StepDefinition):
         description="The status of the step.",
         default=ActionStatus.NOT_STARTED,
     )
-    results: dict[str, ActionResult] = Field(
-        title="Step Results",
-        description="The results of the step.",
-        default_factory=dict,
+    result: Optional[ActionResult] = Field(
+        title="Latest Step Result",
+        description="The result of the latest action run.",
+        default=None,
+    )
+    history: list[ActionResult] = Field(
+        title="Step History",
+        description="The history of the results of the step.",
+        default_factory=list,
     )
     start_time: Optional[datetime] = None
     """Time the step started running"""

--- a/src/madsci_common/madsci/common/types/workcell_types.py
+++ b/src/madsci_common/madsci/common/types/workcell_types.py
@@ -143,11 +143,6 @@ class WorkcellConfig(BaseModel):
         title="Node Update Interval",
         description="The interval at which the workcell queries its node's states, in seconds.Must be <= scheduler_update_interval",
     )
-    heartbeat_interval: float = Field(
-        default=2.0,
-        title="Heartbeat Interval",
-        description="The interval at which the workcell queries its node's states, in seconds.Must be <= scheduler_update_interval",
-    )
     auto_start: bool = Field(
         default=True,
         title="Auto Start",

--- a/src/madsci_common/madsci/common/types/workcell_types.py
+++ b/src/madsci_common/madsci/common/types/workcell_types.py
@@ -1,10 +1,11 @@
 """Types for MADSci Workcell configuration."""
 
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union
 
 from madsci.common.types.base_types import (
     BaseModel,
+    Error,
     LoadConfig,
     ModelLink,
     PathLike,
@@ -12,8 +13,8 @@ from madsci.common.types.base_types import (
 )
 from madsci.common.types.event_types import EventClientConfig
 from madsci.common.types.lab_types import ManagerType
-from madsci.common.types.location_types import Location
-from madsci.common.types.node_types import NodeDefinition
+from madsci.common.types.location_types import Location, LocationDefinition
+from madsci.common.types.node_types import Node, NodeDefinition
 from madsci.common.validators import ulid_validator
 from pydantic import computed_field
 from pydantic.functional_validators import field_validator
@@ -70,7 +71,7 @@ class WorkcellDefinition(BaseModel, extra="allow"):
         title="Workcell Node URLs",
         description="The URL, path, or definition for each node in the workcell.",
     )
-    locations: list[Location] = Field(
+    locations: list[LocationDefinition] = Field(
         default_factory=list,
         title="Workcell Locations",
         description="The Locations used in the workcell.",
@@ -92,6 +93,102 @@ class WorkcellLink(ModelLink[WorkcellDefinition]):
         title="Workcell Definition",
         description="The actual definition of the workcell.",
         default=None,
+    )
+
+
+class WorkcellStatus(BaseModel):
+    """Represents the status of a MADSci workcell."""
+
+    paused: bool = Field(
+        default=False,
+        title="Workcell Paused",
+        description="Whether the workcell is paused.",
+    )
+    errored: bool = Field(
+        default=False,
+        title="Workcell Errored",
+        description="Whether the workcell is in an error state.",
+    )
+    errors: list[Error] = Field(
+        default_factory=list,
+        title="Workcell Errors",
+        description="A list of errors the workcell has encountered.",
+    )
+    initializing: bool = Field(
+        default=False,
+        title="Workcell Initializing",
+        description="Whether the workcell is initializing.",
+    )
+    shutdown: bool = Field(
+        default=False,
+        title="Workcell Shutdown",
+        description="Whether the workcell is shutting down.",
+    )
+    locked: bool = Field(
+        default=False,
+        title="Workcell Locked",
+        description="Whether the workcell is locked.",
+    )
+
+    @computed_field
+    @property
+    def ok(self) -> bool:
+        """Whether the workcell is in a good state."""
+        return not any(
+            [
+                self.paused,
+                self.errored,
+                self.initializing,
+                self.shutdown,
+                self.locked,
+            ]
+        )
+
+    @field_validator("errors", mode="before")
+    @classmethod
+    def ensure_list_of_errors(cls, v: Any) -> Any:
+        """Ensure that errors is a list of MADSci Errors"""
+        if isinstance(v, str):
+            return [Error(message=v)]
+        if isinstance(v, Error):
+            return [v]
+        if isinstance(v, Exception):
+            return [Error.from_exception(v)]
+        if isinstance(v, list):
+            for i, item in enumerate(v):
+                if isinstance(item, str):
+                    v[i] = Error(message=item)
+                elif isinstance(item, Exception):
+                    v[i] = Error.from_exception(item)
+        return v
+
+
+class WorkcellState(BaseModel):
+    """Represents the live state of a MADSci workcell."""
+
+    status: WorkcellStatus = Field(
+        default_factory=WorkcellStatus,
+        title="Workcell Status",
+        description="The status of the workcell.",
+    )
+    workflow_queue: list[str] = Field(
+        default_factory=list,
+        title="Workflow Queue",
+        description="The queue of workflows in non-terminal states.",
+    )
+    workcell_definition: WorkcellDefinition = Field(
+        title="Workcell Definition",
+        description="The definition of the workcell.",
+    )
+    nodes: dict[str, Node] = Field(
+        default_factory=dict,
+        title="Workcell Nodes",
+        description="The nodes in the workcell.",
+    )
+    locations: dict[str, Location] = Field(
+        default_factory=dict,
+        title="Workcell Locations",
+        description="The locations in the workcell.",
     )
 
 

--- a/src/madsci_common/madsci/common/types/workcell_types.py
+++ b/src/madsci_common/madsci/common/types/workcell_types.py
@@ -178,3 +178,8 @@ class WorkcellConfig(BaseModel):
         title="Static Files Path",
         description="Path to the static dashboard files",
     )
+    get_action_result_retries: int = Field(
+        default=3,
+        title="Get Action Result Retries",
+        description="Number of times to retry getting an action result",
+    )

--- a/src/madsci_common/madsci/common/types/workflow_types.py
+++ b/src/madsci_common/madsci/common/types/workflow_types.py
@@ -107,7 +107,7 @@ class Workflow(WorkflowDefinition):
     """ID of the workflow run"""
     steps: list[Step] = Field(default_factory=list)
     """Processed Steps of the flow"""
-    parameter_values: dict[str, Any] = Field(default_factory={})
+    parameter_values: dict[str, Any] = Field(default_factory=dict)
     """parameter values used in this workflow"""
     ownership_info: OwnershipInfo = Field(default_factory=OwnershipInfo)
     """ID of the experiment this workflow is a part of"""

--- a/src/madsci_node_module/madsci/node_module/abstract_node_module.py
+++ b/src/madsci_node_module/madsci/node_module/abstract_node_module.py
@@ -521,7 +521,7 @@ class AbstractNode:
 
                         action_def.args[parameter_name] = ActionArgumentDefinition(
                             name=parameter_name,
-                            type=pretty_type_repr(type_hint),
+                            argument_type=pretty_type_repr(type_hint),
                             default=default,
                             required=is_required,
                             description=description,

--- a/src/madsci_node_module/tests/test_rest_node_module.py
+++ b/src/madsci_node_module/tests/test_rest_node_module.py
@@ -239,15 +239,19 @@ def test_get_info(test_client: TestClient) -> None:
         assert len(node_info.actions) == 4
         assert node_info.actions["test_action"].description == "A test action."
         assert node_info.actions["test_action"].args["test_param"].required
-        assert node_info.actions["test_action"].args["test_param"].type == "int"
+        assert (
+            node_info.actions["test_action"].args["test_param"].argument_type == "int"
+        )
         assert node_info.actions["test_fail"].description == "A test action that fails."
         assert node_info.actions["test_fail"].args["test_param"].required
-        assert node_info.actions["test_fail"].args["test_param"].type == "int"
+        assert node_info.actions["test_fail"].args["test_param"].argument_type == "int"
         assert (
             node_info.actions["test_optional_param_action"].args["test_param"].required
         )
         assert (
-            node_info.actions["test_optional_param_action"].args["test_param"].type
+            node_info.actions["test_optional_param_action"]
+            .args["test_param"]
+            .argument_type
             == "int"
         )
         assert (
@@ -256,7 +260,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_optional_param_action"].args["optional_param"].type
+            node_info.actions["test_optional_param_action"]
+            .args["optional_param"]
+            .argument_type
             == "str"
         )
         assert (
@@ -269,7 +275,8 @@ def test_get_info(test_client: TestClient) -> None:
             not node_info.actions["test_annotation_action"].args["test_param"].required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param"].type == "int"
+            node_info.actions["test_annotation_action"].args["test_param"].argument_type
+            == "int"
         )
         assert (
             node_info.actions["test_annotation_action"].args["test_param"].description
@@ -281,7 +288,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param_2"].type
+            node_info.actions["test_annotation_action"]
+            .args["test_param_2"]
+            .argument_type
             == "int"
         )
         assert (
@@ -294,7 +303,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param_3"].type
+            node_info.actions["test_annotation_action"]
+            .args["test_param_3"]
+            .argument_type
             == "int"
         )
         assert (

--- a/src/madsci_node_module/tests/test_rest_node_module.py
+++ b/src/madsci_node_module/tests/test_rest_node_module.py
@@ -171,6 +171,11 @@ def test_run_action(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         assert (
+            ActionResult.model_validate(response.json()).status == ActionStatus.RUNNING
+        )
+        response = client.get(f"/action/{response.json()['action_id']}")
+        assert response.status_code == 200
+        assert (
             ActionResult.model_validate(response.json()).status
             == ActionStatus.SUCCEEDED
         )
@@ -192,6 +197,11 @@ def test_run_action_fail(test_client: TestClient) -> None:
             "/action",
             params={"action_name": "test_fail", "args": json.dumps({"test_param": 1})},
         )
+        assert ActionResult.model_validate(response.json()).status in [
+            ActionStatus.FAILED,
+            ActionStatus.RUNNING,
+        ]
+        response = client.get(f"/action/{response.json()['action_id']}")
         assert response.status_code == 200
         action_result = ActionResult.model_validate(response.json())
         assert action_result.status == ActionStatus.FAILED
@@ -306,14 +316,13 @@ def test_get_action_result(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.SUCCEEDED
+        assert result.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]
 
         response = client.get(f"/action/{result.action_id}")
         assert response.status_code == 200
         fetched_result = ActionResult.model_validate(response.json())
-        assert fetched_result.status == result.status
+        assert fetched_result.status == ActionStatus.SUCCEEDED
         assert fetched_result.action_id == result.action_id
-        assert fetched_result.history_created_at == result.history_created_at
 
         response = client.get("/action/not_a_valid_id")
         assert response.status_code == 200
@@ -339,7 +348,13 @@ def test_get_action_history(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.SUCCEEDED
+        assert result.status == ActionStatus.RUNNING
+        response = client.get(f"/action/{response.json()['action_id']}")
+        assert response.status_code == 200
+        assert ActionResult.model_validate(response.json()).status in [
+            ActionStatus.RUNNING,
+            ActionStatus.SUCCEEDED,
+        ]
 
         response = client.post(
             "/action",
@@ -350,7 +365,7 @@ def test_get_action_history(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         result2 = ActionResult.model_validate(response.json())
-        assert result2.status == ActionStatus.SUCCEEDED
+        assert result2.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]
 
         response = client.get("/action")
         assert response.status_code == 200
@@ -406,7 +421,7 @@ def test_get_log(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.SUCCEEDED
+        assert result.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]
 
         response = client.get("/log")
         assert response.status_code == 200
@@ -428,7 +443,7 @@ def test_optional_param_action_with_optional_param(test_client: TestClient) -> N
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.SUCCEEDED
+        assert result.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]
 
 
 def test_optional_param_action_without_optional_param(test_client: TestClient) -> None:
@@ -444,4 +459,4 @@ def test_optional_param_action_without_optional_param(test_client: TestClient) -
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.SUCCEEDED
+        assert result.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]

--- a/src/madsci_node_module/tests/test_rest_node_module.py
+++ b/src/madsci_node_module/tests/test_rest_node_module.py
@@ -348,7 +348,7 @@ def test_get_action_history(test_client: TestClient) -> None:
         )
         assert response.status_code == 200
         result = ActionResult.model_validate(response.json())
-        assert result.status == ActionStatus.RUNNING
+        assert result.status in [ActionStatus.RUNNING, ActionStatus.SUCCEEDED]
         response = client.get(f"/action/{response.json()['action_id']}")
         assert response.status_code == 200
         assert ActionResult.model_validate(response.json()).status in [

--- a/src/madsci_workcell_manager/madsci/workcell_manager/condition_checks.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/condition_checks.py
@@ -37,24 +37,24 @@ def evaluate_resource_in_location_condition(
     location = next(
         (
             loc
-            for loc in scheduler.workcell_definition.locations
-            if loc.location_name == condition.location
+            for loc in scheduler.state_handler.get_locations()
+            if condition.location in [loc.location_name, loc.location_id]
         ),
         None,
     )
     if location is None:
         metadata.ready_to_run = False
         metadata.reasons.append(f"Location {condition.location} not found.")
-    elif location.resource is None:
+    elif location.resource_id is None:
         metadata.ready_to_run = False
         metadata.reasons.append(
-            f"Location {location.location_name} cannot provide resource presence information."
+            f"Location {location.location_name} does not have an attached container resource."
         )
     elif scheduler.resource_client is None:
         metadata.ready_to_run = False
         metadata.reasons.append("Resource client is not available.")
     else:
-        container = scheduler.resource_client.get_resource(location.resource)
+        container = scheduler.resource_client.get_resource(location.resource_id)
         if not isinstance(container, Container):
             metadata.ready_to_run = False
             metadata.reasons.append(
@@ -81,24 +81,24 @@ def evaluate_no_resource_in_location_condition(
     location = next(
         (
             loc
-            for loc in scheduler.workcell_definition.locations
-            if loc.location_name == condition.location
+            for loc in scheduler.state_handler.get_locations()
+            if condition.location in [loc.location_name, loc.location_id]
         ),
         None,
     )
     if location is None:
         metadata.ready_to_run = False
         metadata.reasons.append(f"Location {condition.location} not found.")
-    elif location.resource is None:
+    elif location.resource_id is None:
         metadata.ready_to_run = False
         metadata.reasons.append(
-            f"Location {location.location_name} cannot provide resource presence information."
+            f"Location {location.location_name} does not have an attached container resource."
         )
     elif scheduler.resource_client is None:
         metadata.ready_to_run = False
         metadata.reasons.append("Resource client is not available.")
     else:
-        container = scheduler.resource_client.get_resource(location.resource)
+        container = scheduler.resource_client.get_resource(location.resource_id)
         if not isinstance(container, Container):
             metadata.ready_to_run = False
             metadata.reasons.append(

--- a/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
@@ -67,6 +67,9 @@ class WorkcellRedisHandler:
         updated_workcell = self.get_workcell_definition()
         if self._workcell_definition_path is not None:
             updated_workcell.to_yaml(self._workcell_definition_path)
+        status = self.get_workcell_status()
+        status.initializing = False
+        self.set_workcell_status(status)
         self.mark_state_changed()
 
     def initialize_locations_and_resources(
@@ -96,7 +99,7 @@ class WorkcellRedisHandler:
             except KeyError:
                 # * Create new location if it doesn't exist
                 self.set_location(Location.model_validate(location_definition))
-            self._workcell_definition.locations[index] = location_definition
+            workcell.locations[index] = location_definition
         self.set_workcell_definition(workcell)
 
     @property

--- a/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
@@ -6,12 +6,18 @@ import warnings
 from typing import Any, Callable, Optional, Union
 
 import redis
-from madsci.common.types.base_types import new_ulid_str
+from madsci.client.resource_client import ResourceClient
+from madsci.common.types.location_types import Location
 from madsci.common.types.node_types import Node, NodeDefinition
-from madsci.common.types.workcell_types import WorkcellDefinition
+from madsci.common.types.resource_types import Resource
+from madsci.common.types.workcell_types import (
+    WorkcellDefinition,
+    WorkcellState,
+    WorkcellStatus,
+)
 from madsci.common.types.workflow_types import Workflow
 from pottery import InefficientAccessWarning, RedisDict, RedisList, Redlock
-from pydantic import ValidationError
+from pydantic import AnyUrl, ValidationError
 
 
 class WorkcellRedisHandler:
@@ -31,16 +37,71 @@ class WorkcellRedisHandler:
         """
         Initialize a StateManager for a given workcell.
         """
-        self._workcell_name = workcell_definition.workcell_name
+        self._workcell_id = workcell_definition.workcell_id
+        self._workcell_definition_path = workcell_definition._definition_path
         self._redis_host = workcell_definition.config.redis_host
         self._redis_port = workcell_definition.config.redis_port
         self._redis_password = workcell_definition.config.redis_password
         self._redis_connection = redis_connection
         warnings.filterwarnings("ignore", category=InefficientAccessWarning)
+        self.set_workcell_definition(workcell_definition)
+
+    def initialize_workcell_state(
+        self, resource_client: Optional[ResourceClient] = None
+    ) -> None:
+        """
+        Initializes the state of the workcell from the workcell definition.
+        """
+        self.set_workcell_status(WorkcellStatus(initializing=True))
+        self._nodes.clear()
+        self.state_change_marker = "0"
+        # * Initialize Nodes
+        for key, value in self.get_workcell_definition().nodes.items():
+            if isinstance(value, NodeDefinition):
+                node = Node(node_url=value.node_url)
+            elif isinstance(value, (AnyUrl, str)):
+                node = Node(node_url=AnyUrl(value))
+            self.set_node(key, node)
+        # * Initialize Locations and Resources
+        self.initialize_locations_and_resources(resource_client)
+        updated_workcell = self.get_workcell_definition()
+        if self._workcell_definition_path is not None:
+            updated_workcell.to_yaml(self._workcell_definition_path)
+        self.mark_state_changed()
+
+    def initialize_locations_and_resources(
+        self, resource_client: Optional[ResourceClient] = None
+    ) -> None:
+        """Set the workcell's location based on the location definitions in the workcell, and create resources if necessary/possible"""
+        workcell = self.get_workcell_definition()
+        for index in range(len(workcell.locations)):
+            location_definition = workcell.locations[index]
+            if (
+                location_definition.resource_definition is not None
+                and resource_client is not None
+                and location_definition.resource_id is None
+            ):
+                resource = Resource.discriminate(
+                    location_definition.resource_definition
+                )
+                resource = resource_client.add_resource(resource)
+                location_definition.resource_id = resource.resource_id
+            try:
+                # * Update existing location if it exists
+                existing_location = self.get_location(location_definition.location_id)
+                existing_location = existing_location.model_copy(
+                    update=location_definition.model_dump()
+                )
+                self.set_location(existing_location)
+            except KeyError:
+                # * Create new location if it doesn't exist
+                self.set_location(Location.model_validate(location_definition))
+            self._workcell_definition.locations[index] = location_definition
+        self.set_workcell_definition(workcell)
 
     @property
     def _workcell_prefix(self) -> str:
-        return f"workcell:{self._workcell_name}"
+        return f"madsci:workcell:{self._workcell_id}"
 
     @property
     def _redis_client(self) -> Any:
@@ -59,14 +120,20 @@ class WorkcellRedisHandler:
         return self._redis_connection
 
     @property
-    def _workcell(self) -> RedisDict:
+    def _workcell_definition(self) -> RedisDict:
         return RedisDict(
-            key=f"{self._workcell_prefix}:workcell", redis=self._redis_client
+            key=f"{self._workcell_prefix}:workcell_definition", redis=self._redis_client
         )
 
     @property
     def _nodes(self) -> RedisDict:
         return RedisDict(key=f"{self._workcell_prefix}:nodes", redis=self._redis_client)
+
+    @property
+    def _locations(self) -> RedisDict:
+        return RedisDict(
+            key=f"{self._workcell_prefix}:locations", redis=self._redis_client
+        )
 
     @property
     def _workflow_queue(self) -> RedisList:
@@ -78,6 +145,12 @@ class WorkcellRedisHandler:
     def _workflows(self) -> RedisDict:
         return RedisDict(
             key=f"{self._workcell_prefix}:workflows", redis=self._redis_client
+        )
+
+    @property
+    def _workcell_status(self) -> RedisDict:
+        return RedisDict(
+            key=f"{self._workcell_prefix}:status", redis=self._redis_client
         )
 
     def wc_state_lock(self) -> Redlock:
@@ -92,44 +165,32 @@ class WorkcellRedisHandler:
         )
 
     # *State Methods
-    def get_state(self) -> dict[str, dict[Any, Any]]:
+    def get_workcell_state(self) -> WorkcellState:
         """
-        Return a dict containing the current state of the workcell.
+        Return the current state of the workcell.
         """
-        return {
-            "error": self.error,
-            "nodes": self._nodes.to_dict(),
-            "workflows": self._workflows.to_dict(),
-            "workcell": self._workcell.to_dict(),
-            "paused": self.paused,
-            "locked": self.locked,
-            "shutdown": self.shutdown,
-        }
+        return WorkcellState(
+            status=self.get_workcell_status(),
+            workflow_queue=self.get_workflow_queue(),
+            workcell_definition=self.get_workcell_definition(),
+            nodes=self.get_nodes(),
+            locations=self.get_locations(),
+        )
 
-    @property
-    def error(self) -> str:
-        """Latest error on the server"""
-        return self._redis_client.get(f"{self._workcell_prefix}:error")
+    def get_workcell_status(self) -> WorkcellStatus:
+        """Return the current status of the workcell"""
+        return WorkcellStatus.model_validate(self._workcell_status)
 
-    @error.setter
-    def error(self, value: str) -> None:
-        """Add an error to the workcell's error deque"""
-        if self.error != value:
-            self.mark_state_changed()
-        return self._redis_client.set(f"{self._workcell_prefix}:error", value)
-
-    def clear_state(self, clear_workflows: bool = False) -> None:
-        """
-        Clears the state of the workcell, optionally leaving the locations state intact.
-        """
-        self._nodes.clear()
-        if clear_workflows:
-            self._workflows.clear()
-        self.state_change_marker = "0"
-        self.paused = False
-        self.locked = False
-        self.shutdown = False
+    def set_workcell_status(self, status: WorkcellStatus) -> None:
+        """Set the status of the workcell"""
+        self._workcell_status.update(**status.model_dump(mode="json"))
         self.mark_state_changed()
+
+    def update_workcell_status(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> None:
+        """Update the status of the workcell"""
+        self.set_workcell_status(func(self.get_workcell_status(), *args, **kwargs))
 
     def mark_state_changed(self) -> int:
         """Marks the state as changed and returns the current state change counter"""
@@ -146,35 +207,34 @@ class WorkcellRedisHandler:
         return False
 
     # *Workcell Methods
-    def get_workcell(self) -> WorkcellDefinition:
+    def get_workcell_definition(self) -> WorkcellDefinition:
         """
-        Returns the current workcell as a Workcell object
+        Returns the current workcell definition as a WorkcellDefinition object
         """
-        return WorkcellDefinition.model_validate(self._workcell.to_dict())
+        return WorkcellDefinition.model_validate(self._workcell_definition.to_dict())
 
-    def set_workcell(self, workcell: WorkcellDefinition) -> None:
+    def set_workcell_definition(self, workcell: WorkcellDefinition) -> None:
         """
         Sets the active workcell
         """
-        self._workcell.update(**workcell.model_dump(mode="json"))
+        self.clear_workcell_definition()
+        self._workcell_definition.update(**workcell.model_dump(mode="json"))
 
-    def clear_workcell(self) -> None:
+    def clear_workcell_definition(self) -> None:
         """
         Empty the workcell definition
         """
-        self._workcell.clear()
+        self._workcell_definition.clear()
 
-    def get_workcell_id(self) -> str:
+    def update_workcell_definition(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> None:
         """
-        Returns the workcell ID
+        Updates the workcell definition
         """
-        wc_id = self._redis_client.get(f"{self._workcell_prefix}:workcell_id")
-        if wc_id is None:
-            self._redis_client.set(
-                f"{self._workcell_prefix}:workcell_id", new_ulid_str()
-            )
-            wc_id = self._redis_client.get(f"{self._workcell_prefix}:workcell_id")
-        return wc_id
+        self.set_workcell_definition(
+            func(self.get_workcell_definition(), *args, **kwargs)
+        )
 
     # *Workflow Methods
     def get_workflow(self, workflow_id: Union[str, str]) -> Workflow:
@@ -183,7 +243,7 @@ class WorkcellRedisHandler:
         """
         return Workflow.model_validate(self._workflows[str(workflow_id)])
 
-    def get_all_workflows(self) -> dict[str, Workflow]:
+    def get_workflows(self) -> dict[str, Workflow]:
         """
         Returns all workflow runs
         """
@@ -195,18 +255,26 @@ class WorkcellRedisHandler:
                 continue
         return valid_workflows
 
-    def set_workflow(self, wf: Workflow) -> None:
+    def get_workflow_queue(self) -> list[Workflow]:
         """
-        Sets a workflow by ID
+        Returns the workflow queue
         """
-        if isinstance(wf, Workflow):
-            wf_dump = wf.model_dump(mode="json")
-        else:
-            wf_dump = Workflow.model_validate(wf).model_dump(mode="json")
-        self._workflows[str(wf_dump["workflow_id"])] = wf_dump
+        return [self.get_workflow(wf_id) for wf_id in self._workflow_queue]
+
+    def update_workflow_queue(self) -> None:
+        """
+        Sets the workflow queue based on the current state of the workflows
+        """
+        workflow_queue = [
+            wf_id
+            for wf_id in self._workflows
+            if not self.get_workflow(wf_id).status.is_active
+        ]
+        self._workflow_queue.clear()
+        self._workflow_queue.extend(workflow_queue)
         self.mark_state_changed()
 
-    def set_workflow_quiet(self, wf: Workflow) -> None:
+    def set_workflow(self, wf: Workflow, mark_state_changed: bool = True) -> None:
         """
         Sets a workflow by ID
         """
@@ -215,6 +283,8 @@ class WorkcellRedisHandler:
         else:
             wf_dump = Workflow.model_validate(wf).model_dump(mode="json")
         self._workflows[str(wf_dump["workflow_id"])] = wf_dump
+        if mark_state_changed:
+            self.mark_state_changed()
 
     def delete_workflow(self, workflow_id: Union[str, str]) -> None:
         """
@@ -237,7 +307,7 @@ class WorkcellRedisHandler:
         """
         return Node.model_validate(self._nodes[node_name])
 
-    def get_all_nodes(self) -> dict[str, Node]:
+    def get_nodes(self) -> dict[str, Node]:
         """
         Returns all nodes
         """
@@ -280,3 +350,49 @@ class WorkcellRedisHandler:
         Updates the state of a node.
         """
         self.set_node(node_name, func(self.get_node(node_name), *args, **kwargs))
+
+    def get_location(self, location_id: str) -> Location:
+        """
+        Returns a location by ID
+        """
+        return Location.model_validate(self._locations[location_id])
+
+    def get_locations(self) -> dict[str, Location]:
+        """
+        Returns all locations
+        """
+        valid_locations = {}
+        for location in self._locations:
+            try:
+                valid_locations[location] = Location.model_validate(
+                    self._locations[location]
+                )
+            except ValidationError:
+                continue
+        return valid_locations
+
+    def set_location(self, location: Union[Location, dict[str, Any]]) -> None:
+        """
+        Sets a location by ID
+        """
+        if isinstance(location, Location):
+            location_dump = location.model_dump(mode="json")
+        else:
+            location_dump = Location.model_validate(location).model_dump(mode="json")
+        self._locations[location_dump["location_id"]] = location_dump
+        self.mark_state_changed()
+
+    def delete_location(self, location_id: str) -> None:
+        """
+        Deletes a location by ID
+        """
+        del self._locations[location_id]
+        self.mark_state_changed()
+
+    def update_location(
+        self, location_id: str, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> None:
+        """
+        Updates the state of a location.
+        """
+        self.set_location(func(self.get_location(location_id), *args, **kwargs))

--- a/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/redis_handler.py
@@ -268,13 +268,10 @@ class WorkcellRedisHandler:
         """
         Sets the workflow queue based on the current state of the workflows
         """
-        workflow_queue = [
-            wf_id
-            for wf_id in self._workflows
-            if not self.get_workflow(wf_id).status.is_active
-        ]
         self._workflow_queue.clear()
-        self._workflow_queue.extend(workflow_queue)
+        for wf in self.get_workflows().values():
+            if wf.status.is_active:
+                self._workflow_queue.append(wf.workflow_id)
         self.mark_state_changed()
 
     def set_workflow(self, wf: Workflow, mark_state_changed: bool = True) -> None:

--- a/src/madsci_workcell_manager/madsci/workcell_manager/schedulers/scheduler.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/schedulers/scheduler.py
@@ -4,18 +4,23 @@ from typing import ClassVar, Optional
 
 from madsci.client.event_client import EventClient
 from madsci.client.resource_client import ResourceClient
-from madsci.common.types.event_types import Event
 from madsci.common.types.workcell_types import WorkcellDefinition
-from madsci.common.types.workflow_types import Workflow
+from madsci.common.types.workflow_types import SchedulerMetadata, Workflow
 from madsci.workcell_manager.redis_handler import WorkcellRedisHandler
 
 
-def send_event(test: Event) -> None:  # TODO: remove placeholder
-    """send an event to the server"""
-
-
 class AbstractScheduler:
-    """abstract definition of a scheduler"""
+    """Abstract Implementation of a MADSci Workcell Scheduler.
+
+    All schedulers should:
+
+    - Take a list of MADSci Workflow objects as input to the run_iteration method
+    - Set the ready_to_run flag in each workflow's scheduler metadata, optionally setting a list of reasons why the workflow is not ready to run (this is useful for debugging and understanding why a workflow is not running)
+    - Set the priority of the workflows, based on whatever criteria the scheduler uses
+
+    The run_iteration method will be called by the WorkcellManager at a regular interval to determine which workflows are ready to run and in what order they should be run. It will then be up to the WorkcellManager to actually run the workflows in the order determined by the scheduler. The scheduler should not actually run the workflows itself. The scheduler should also not modify the workflows or other state.
+
+    """
 
     workcell_definition: ClassVar[WorkcellDefinition]
     running: bool
@@ -42,5 +47,6 @@ class AbstractScheduler:
         else:
             self.resource_client = None
 
-    def run_iteration(self, workflows: list[Workflow]) -> None:
-        """Run an iteration of the scheduler"""
+    def run_iteration(self, workflows: list[Workflow]) -> dict[str, SchedulerMetadata]:
+        """Run an iteration of the scheduler and return a mapping of workflow IDs to SchedulerMetadata"""
+        raise NotImplementedError("Subclasses must implement this method")

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
@@ -24,7 +24,6 @@ from madsci.common.utils import threaded_daemon
 from madsci.workcell_manager.redis_handler import WorkcellRedisHandler
 from madsci.workcell_manager.workcell_utils import (
     find_node_client,
-    initialize_workcell,
     update_active_nodes,
 )
 from madsci.workcell_manager.workflow_utils import cancel_active_workflows
@@ -56,8 +55,7 @@ class Engine:
         )
         self.logger.log_debug(self.data_client.url)
         with state_handler.wc_state_lock():
-            initialize_workcell(
-                state_handler,
+            state_handler.initialize_workcell_state(
                 self.resource_client,
             )
         time.sleep(workcell_definition.config.cold_start_delay)

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
@@ -9,18 +9,21 @@ from typing import Annotated, Any, Optional, Union
 from fastapi import FastAPI, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from madsci.client.event_client import EventClient
+from madsci.client.resource_client import ResourceClient
 from madsci.common.types.action_types import ActionStatus
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.base_types import new_ulid_str
+from madsci.common.types.location_types import Location
 from madsci.common.types.node_types import Node, NodeDefinition
-from madsci.common.types.workcell_types import WorkcellDefinition
+from madsci.common.types.workcell_types import WorkcellDefinition, WorkcellState
 from madsci.common.types.workflow_types import (
     Workflow,
     WorkflowDefinition,
     WorkflowStatus,
 )
 from madsci.workcell_manager.redis_handler import WorkcellRedisHandler
-from madsci.workcell_manager.workcell_engine import Engine
+from madsci.workcell_manager.workcell_engine import Engine, initialize_workcell
 from madsci.workcell_manager.workcell_utils import find_node_client
 from madsci.workcell_manager.workflow_utils import (
     copy_workflow_files,
@@ -41,10 +44,19 @@ def create_workcell_server(  # noqa: C901, PLR0915
     @asynccontextmanager
     async def lifespan(app: FastAPI):  # noqa: ANN202, ARG001
         """Start the REST server and initialize the state handler and engine"""
-        state_handler.set_workcell(workcell)
         if start_engine:
-            engine = Engine(workcell, state_handler)
+            engine = Engine(state_handler)
             engine.spin()
+        else:
+            with state_handler.wc_state_lock():
+                initialize_workcell(
+                    state_manager=state_handler,
+                    resource_client=ResourceClient(
+                        url=workcell.config.resource_server_url
+                    )
+                    if workcell.config.resource_server_url is not None
+                    else None,
+                )
         yield
 
     app = FastAPI(lifespan=lifespan)
@@ -53,17 +65,17 @@ def create_workcell_server(  # noqa: C901, PLR0915
     @app.get("/workcell")
     def get_workcell() -> WorkcellDefinition:
         """Get the currently running workcell."""
-        return state_handler.get_workcell()
+        return state_handler.get_workcell_definition()
 
     @app.get("/state")
-    def get_state() -> dict:
+    def get_state() -> WorkcellState:
         """Get the current state of the workcell."""
-        return state_handler.get_state()
+        return state_handler.get_workcell_state()
 
     @app.get("/nodes")
     def get_nodes() -> dict[str, Node]:
         """Get info on the nodes in the workcell."""
-        return state_handler.get_all_nodes()
+        return state_handler.get_nodes()
 
     @app.get("/nodes/{node_name}")
     def get_node(node_name: str) -> Union[Node, str]:
@@ -82,7 +94,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
         permanent: bool = False,
     ) -> Union[Node, str]:
         """Add a node to the workcell's node list"""
-        if node_name in state_handler.get_all_nodes():
+        if node_name in state_handler.get_nodes():
             return "Node name exists, node names must be unique!"
         node = Node(node_url=node_url)
         state_handler.set_node(node_name, node)
@@ -99,7 +111,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
     def send_admin_command(command: str) -> list:
         """Send an admin command to all capable nodes."""
         responses = []
-        for node in state_handler.get_all_nodes().values():
+        for node in state_handler.get_nodes().values():
             if command in node.info.capabilities.admin_commands:
                 client = find_node_client(node.node_url)
                 response = client.send_admin_command(command)
@@ -118,16 +130,21 @@ def create_workcell_server(  # noqa: C901, PLR0915
         return responses
 
     @app.get("/workflows")
-    def get_all_workflows() -> dict[str, Workflow]:
-        """get all workflows."""
-        return state_handler.get_all_workflows()
+    def get_workflows() -> dict[str, Workflow]:
+        """Get all workflows."""
+        return state_handler.get_workflows()
 
-    @app.get("/workflows/{workflow_id}")
+    @app.get("/workflow/queue")
+    def get_workflow_queue() -> list[Workflow]:
+        """Get all queued workflows."""
+        return state_handler.get_workflow_queue()
+
+    @app.get("/workflow/{workflow_id}")
     def get_workflow(workflow_id: str) -> Workflow:
         """Get info on a specific workflow."""
         return state_handler.get_workflow(workflow_id)
 
-    @app.post("/workflows/pause/{workflow_id}")
+    @app.post("/workflow/{workflow_id}/pause")
     def pause_workflow(workflow_id: str) -> Workflow:
         """Pause a specific workflow."""
         with state_handler.wc_state_lock():
@@ -141,7 +158,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
 
         return state_handler.get_workflow(workflow_id)
 
-    @app.post("/workflows/resume/{workflow_id}")
+    @app.post("/workflow/{workflow_id}/resume")
     def resume_workflow(workflow_id: str) -> Workflow:
         """Resume a paused workflow."""
         with state_handler.wc_state_lock():
@@ -154,7 +171,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
                 state_handler.set_workflow(wf)
         return state_handler.get_workflow(workflow_id)
 
-    @app.post("/workflows/cancel/{workflow_id}")
+    @app.post("/workflow/{workflow_id}/cancel")
     def cancel_workflow(workflow_id: str) -> Workflow:
         """Cancel a specific workflow."""
         with state_handler.wc_state_lock():
@@ -166,7 +183,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
             state_handler.set_workflow(wf)
         return state_handler.get_workflow(workflow_id)
 
-    @app.post("/workflows/resubmit/{workflow_id}")
+    @app.post("/workflow/{workflow_id}/resubmit")
     def resubmit_workflow(workflow_id: str) -> Workflow:
         """resubmit a previous workflow as a new workflow."""
         with state_handler.wc_state_lock():
@@ -189,7 +206,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
             state_handler.set_workflow(wf)
         return state_handler.get_workflow(wf.workflow_id)
 
-    @app.post("/workflows/retry/{workflow_id}")
+    @app.post("/workflow/{workflow_id}/retry")
     def retry_workflow(workflow_id: str, index: int = -1) -> Workflow:
         """Retry an existing workflow from a specific step."""
         with state_handler.wc_state_lock():
@@ -205,7 +222,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
                 state_handler.set_workflow(wf)
         return state_handler.get_workflow(workflow_id)
 
-    @app.post("/workflows/start")
+    @app.post("/workflow")
     async def start_workflow(
         workflow: Annotated[str, Form()],
         ownership_info: Annotated[Optional[str], Form()] = None,
@@ -256,7 +273,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
                     status_code=400,
                     detail="Parameters must be a dictionary with string keys",
                 )
-        workcell = state_handler.get_workcell()
+        workcell = state_handler.get_workcell_definition()
         wf = create_workflow(
             workflow_def=wf_def,
             workcell=workcell,
@@ -275,10 +292,54 @@ def create_workcell_server(  # noqa: C901, PLR0915
                 state_handler.set_workflow(wf)
         return wf
 
+    @app.get("/locations")
+    def get_locations() -> dict[str, Location]:
+        """Get the locations of the workcell."""
+        return state_handler.get_locations()
+
+    @app.post("/location")
+    def add_location(
+        location: Location,
+    ) -> Location:
+        """Add a location to the workcell's location list"""
+        with state_handler.wc_state_lock():
+            state_handler.set_location(location.location_id, location)
+        return state_handler.get_location(location.location_id)
+
+    @app.get("/location/{location_id}")
+    def get_location(location_id: str) -> Location:
+        """Get information about about a specific location."""
+        return state_handler.get_location(location_id)
+
+    @app.delete("/location/{location_id}")
+    def delete_location(location_id: str) -> dict:
+        """Delete a location from the workcell's location list"""
+        with state_handler.wc_state_lock():
+            state_handler.delete_location(location_id)
+        return {"status": "deleted"}
+
+    @app.post("/location/{location_id}/attach_resource")
+    def add_resource_to_location(
+        location_id: str,
+        resource_id: str,
+    ) -> Location:
+        """Attach a resource container to a location."""
+        with state_handler.wc_state_lock():
+            location = state_handler.get_location(location_id)
+            location.resource_id = resource_id
+            state_handler.set_location(location_id, location)
+        return state_handler.get_location(location_id)
+
     if workcell.config.static_files_path is not None:
-        app.mount(
-            "/", StaticFiles(directory=workcell.config.static_files_path, html=True)
-        )
+        try:
+            app.mount(
+                "/", StaticFiles(directory=workcell.config.static_files_path, html=True)
+            )
+        except Exception:
+            EventClient(workcell.config.event_client_config).log_error(
+                f"Error mounting static files: {workcell.config.static_files_path}"
+            )
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
@@ -134,7 +134,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
         """Get all workflows."""
         return state_handler.get_workflows()
 
-    @app.get("/workflow/queue")
+    @app.get("/workflows/queue")
     def get_workflow_queue() -> list[Workflow]:
         """Get all queued workflows."""
         return state_handler.get_workflow_queue()

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_server.py
@@ -44,7 +44,7 @@ def create_workcell_server(  # noqa: C901, PLR0915
         state_handler.set_workcell(workcell)
         if start_engine:
             engine = Engine(workcell, state_handler)
-            engine.start_engine_thread()
+            engine.spin()
         yield
 
     app = FastAPI(lifespan=lifespan)

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_utils.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_utils.py
@@ -2,7 +2,6 @@
 
 import concurrent
 import warnings
-from typing import Optional
 
 import requests
 import yaml
@@ -31,17 +30,15 @@ def resolve_workcell_link(workcell_link: WorkcellLink) -> WorkcellDefinition:
 def initialize_workcell(
     state_manager: WorkcellRedisHandler,
     resource_client: ResourceClient,
-    workcell: Optional[WorkcellDefinition] = None,
 ) -> None:
     """
     Initializes the state of the workcell from the workcell definition.
     """
 
-    if not workcell:
-        workcell = state_manager.get_workcell()
+    workcell = state_manager.get_workcell_definition()
     initialize_workcell_nodes(workcell, state_manager)
     initialize_workcell_resources(workcell, resource_client)
-    state_manager.set_workcell(workcell)
+    state_manager.set_workcell_definition(workcell)
 
 
 def initialize_workcell_nodes(
@@ -75,7 +72,7 @@ def initialize_workcell_resources(
 
 
 def find_node_client(url: str) -> AbstractNodeClient:
-    """finds the right client for the node url provided"""
+    """Finds the appropriate node client based on a given node url"""
     for client in NODE_CLIENT_MAP.values():
         if client.validate_url(url):
             return client(url)
@@ -89,7 +86,7 @@ def update_active_nodes(state_manager: WorkcellRedisHandler) -> None:
     """Update all active nodes in the workcell."""
     with concurrent.futures.ThreadPoolExecutor() as executor:
         node_futures = []
-        for node_name, node in state_manager.get_all_nodes().items():
+        for node_name, node in state_manager.get_nodes().items():
             node_future = executor.submit(update_node, node_name, node, state_manager)
             node_futures.append(node_future)
 

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workflow_utils.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workflow_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 
 from fastapi import UploadFile
 from madsci.client.event_client import default_logger
+from madsci.common.data_manipulation import value_substitution, walk_and_replace
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.location_types import Location
 from madsci.common.types.node_types import Node
@@ -33,7 +34,7 @@ def validate_node_names(workflow: Workflow, workcell: WorkcellDefinition) -> Non
 
 def validate_step(step: Step, state_handler: WorkcellRedisHandler) -> tuple[bool, str]:
     """Check if a step is valid based on the node's info"""
-    if step.node in state_handler.get_all_nodes():
+    if step.node in state_handler.get_nodes():
         node = state_handler.get_node(step.node)
         info = node.info
         if info is None:
@@ -113,7 +114,7 @@ def create_workflow(
     steps = []
     for step in workflow_def.steps:
         working_step = deepcopy(step)
-        nodes = state_handler.get_all_nodes()
+        nodes = state_handler.get_nodes()
         replace_locations(workcell, working_step, nodes)
         valid, validation_string = validate_step(
             working_step, state_handler=state_handler
@@ -156,7 +157,7 @@ def replace_locations(
     for argument, value in step.args.items():
         try:
             if (
-                nodes[step.node].info.actions[step.action].args[argument].type
+                nodes[step.node].info.actions[step.action].args[argument].argument_type
                 == "NodeLocation"
             ):
                 target_loc = next(
@@ -238,10 +239,35 @@ def cancel_workflow(wf: Workflow, state_handler: WorkcellRedisHandler) -> None:
 
 def cancel_active_workflows(state_handler: WorkcellRedisHandler) -> None:
     """Cancels all currently running workflow runs"""
-    for wf in state_handler.get_all_workflows().values():
+    for wf in state_handler.get_workflows().values():
         if wf.status in [
             WorkflowStatus.RUNNING,
             WorkflowStatus.QUEUED,
             WorkflowStatus.IN_PROGRESS,
         ]:
             cancel_workflow(wf, state_handler=state_handler)
+
+
+def insert_parameter_values(
+    workflow: WorkflowDefinition, parameters: dict[str, Any]
+) -> Workflow:
+    """Replace the parameter strings in the workflow with the provided values"""
+    for param in workflow.parameters:
+        if param.name not in parameters:
+            if param.default:
+                parameters[param.name] = param.default
+            else:
+                raise ValueError(
+                    "Workflow parameter: "
+                    + param.name
+                    + " not provided, and no default value is defined."
+                )
+    steps = []
+    for step in workflow.steps:
+        for key, val in iter(step):
+            if type(val) is str:
+                setattr(step, key, value_substitution(val, parameters))
+
+        step.args = walk_and_replace(step.args, parameters)
+        steps.append(step)
+    workflow.steps = steps

--- a/src/madsci_workcell_manager/tests/test_default_scheduler.py
+++ b/src/madsci_workcell_manager/tests/test_default_scheduler.py
@@ -1,0 +1,181 @@
+"""Tests for the default scheduler"""
+
+from collections.abc import Generator
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from madsci.client.resource_client import Resource
+from madsci.common.types.condition_types import (
+    NoResourceInLocationCondition,
+    ResourceInLocationCondition,
+)
+from madsci.common.types.location_types import Location
+from madsci.common.types.node_types import Node, NodeInfo, NodeStatus
+from madsci.common.types.resource_types import Slot
+from madsci.common.types.step_types import Step
+from madsci.common.types.workcell_types import WorkcellDefinition
+from madsci.common.types.workflow_types import (
+    SchedulerMetadata,
+    Workflow,
+    WorkflowStatus,
+)
+from madsci.workcell_manager.schedulers.default_scheduler import Scheduler
+
+
+@pytest.fixture
+def mock_scheduler() -> Generator[Scheduler, None, None]:
+    """Fixture to create a mock scheduler"""
+    mock_workcell_definition = WorkcellDefinition(
+        workcell_name="test workcell",
+        locations=[
+            Location(
+                location_name="loc1",
+                resource=None,
+            ),
+            Location(
+                location_name="loc2",
+                resource=None,
+            ),
+        ],
+    )
+    mock_state_handler = MagicMock()
+    mock_state_handler.get_node.return_value = Node(
+        node_url="http://test_node",
+        status=NodeStatus(),
+        info=NodeInfo(
+            node_name="test_node",
+            module_name="test_module",
+        ),
+    )
+    scheduler = Scheduler(mock_workcell_definition, mock_state_handler)
+    yield scheduler
+
+
+@pytest.fixture
+def workflows() -> list[Workflow]:
+    """Fixture to create a list of workflows"""
+    now = datetime.now()
+    return [
+        Workflow(
+            name="wf1",
+            submitted_time=now - timedelta(minutes=10),
+            steps=[Step(name="step1", action="test_action", node="test_node")],
+            status=WorkflowStatus.QUEUED,
+        ),
+        Workflow(
+            name="wf2",
+            submitted_time=now - timedelta(minutes=5),
+            steps=[Step(name="step2", action="test_action", node="test_node")],
+            status=WorkflowStatus.QUEUED,
+        ),
+    ]
+
+
+def test_fifo_prioritization(
+    mock_scheduler: Scheduler, workflows: list[Workflow]
+) -> None:
+    """Test that workflows are prioritized based on FIFO from their submission dates"""
+    result = mock_scheduler.run_iteration(workflows)
+    assert (
+        result[workflows[0].workflow_id].priority
+        > result[workflows[1].workflow_id].priority
+    )
+    workflows_reversed = [workflows[1], workflows[0]]
+    result = mock_scheduler.run_iteration(workflows_reversed)
+    assert (
+        result[workflows[0].workflow_id].priority
+        > result[workflows[1].workflow_id].priority
+    )
+
+
+def test_condition_checking_no_resource_info_for_location(
+    mock_scheduler: Scheduler,
+) -> None:
+    """Test that conditions are evaluated correctly when no resource information is available for a location"""
+    workflows: list[Workflow] = [
+        Workflow(
+            name="wf1",
+            submitted_time=datetime.now(),
+            steps=[
+                Step(
+                    name="step1",
+                    action="test_action",
+                    node="test_node",
+                    conditions=[
+                        ResourceInLocationCondition(location="loc1"),
+                        NoResourceInLocationCondition(location="loc2"),
+                    ],
+                )
+            ],
+            status=WorkflowStatus.QUEUED,
+        )
+    ]
+    mock_scheduler.resource_client = MagicMock()
+    mock_scheduler.resource_client.get_resource.return_value = None
+
+    result: dict[str, SchedulerMetadata] = mock_scheduler.run_iteration(workflows)
+    metadata = result[workflows[0].workflow_id]
+    assert not metadata.ready_to_run
+    assert len(metadata.reasons) > 0
+    assert "cannot provide resource presence information" in metadata.reasons[0]
+    assert "cannot provide resource presence information" in metadata.reasons[1]
+
+
+def test_condition_checking_resource_presence(mock_scheduler: Scheduler) -> None:
+    """Test that conditions are evaluated correctly when no resource information is available for a location"""
+    workflows: list[Workflow] = [
+        Workflow(
+            name="wf1",
+            submitted_time=datetime.now(),
+            steps=[
+                Step(
+                    name="step1",
+                    action="test_action",
+                    node="test_node",
+                    conditions=[
+                        ResourceInLocationCondition(location="loc1"),
+                        NoResourceInLocationCondition(location="loc2"),
+                    ],
+                )
+            ],
+            status=WorkflowStatus.QUEUED,
+        )
+    ]
+    mock_scheduler.resource_client = MagicMock()
+    test_slot = Slot()
+    mock_scheduler.resource_client.get_resource.return_value = test_slot
+    mock_scheduler.workcell_definition.locations[0].resource = test_slot
+    mock_scheduler.workcell_definition.locations[1].resource = test_slot
+
+    result: dict[str, SchedulerMetadata] = mock_scheduler.run_iteration(workflows)
+    metadata = result[workflows[0].workflow_id]
+    assert not metadata.ready_to_run
+    assert len(metadata.reasons) > 0
+    assert "is empty" in metadata.reasons[0]
+
+    mock_scheduler.resource_client.get_resource.return_value = Resource()
+
+    result: dict[str, SchedulerMetadata] = mock_scheduler.run_iteration(workflows)
+    metadata = result[workflows[0].workflow_id]
+    assert not metadata.ready_to_run
+    assert len(metadata.reasons) > 0
+    assert "is not a container." in metadata.reasons[0]
+    assert "is not a container." in metadata.reasons[1]
+
+    test_slot.children = [Resource()]
+    mock_scheduler.resource_client.get_resource.return_value = test_slot
+
+    result: dict[str, SchedulerMetadata] = mock_scheduler.run_iteration(workflows)
+    metadata = result[workflows[0].workflow_id]
+    assert not metadata.ready_to_run
+    assert len(metadata.reasons) > 0
+    assert "is not empty." in metadata.reasons[0]
+
+
+def test_workflow_paused(mock_scheduler: Scheduler, workflows: list[Workflow]) -> None:
+    """Test that paused workflows are marked as not ready to run"""
+    workflows[0].paused = True
+    result: dict[str, SchedulerMetadata] = mock_scheduler.run_iteration(workflows)
+    assert not result[workflows[0].workflow_id].ready_to_run
+    assert "Workflow is paused" in result[workflows[0].workflow_id].reasons

--- a/src/madsci_workcell_manager/tests/test_workcell_engine.py
+++ b/src/madsci_workcell_manager/tests/test_workcell_engine.py
@@ -1,7 +1,7 @@
 """Automated unit tests for the Workcell Engine, using pytest."""
 
 import copy
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from madsci.common.types.action_types import (
@@ -15,94 +15,80 @@ from madsci.common.types.datapoint_types import FileDataPoint, ValueDataPoint
 from madsci.common.types.node_types import Node, NodeCapabilities, NodeInfo
 from madsci.common.types.step_types import Step
 from madsci.common.types.workcell_types import WorkcellConfig, WorkcellDefinition
-from madsci.common.types.workflow_types import Workflow, WorkflowStatus
+from madsci.common.types.workflow_types import (
+    SchedulerMetadata,
+    Workflow,
+    WorkflowStatus,
+)
 from madsci.workcell_manager.redis_handler import WorkcellRedisHandler
 from madsci.workcell_manager.workcell_engine import Engine
+from pytest_mock_resources import RedisConfig, create_redis_fixture
+from redis import Redis
+
+
+# Create a Redis server fixture for testing
+@pytest.fixture(scope="session")
+def pmr_redis_config() -> RedisConfig:
+    """Configure the Redis server."""
+    return RedisConfig(image="redis:7.4")
+
+
+redis_server = create_redis_fixture()
 
 
 @pytest.fixture
-def mock_workcell_definition() -> WorkcellDefinition:
-    """Fixture for a mock WorkcellDefinition."""
-    return WorkcellDefinition(
+def state_handler(redis_server: Redis) -> WorkcellRedisHandler:
+    """Fixture for creating a WorkcellRedisHandler."""
+    workcell_def = WorkcellDefinition(
         workcell_name="Test Workcell",
-        config=WorkcellConfig(
-            clear_workflows=True,
-            scheduler="madsci.workcell_manager.scheduler",
-            data_server_url="http://data-server",
-            resource_server_url="http://resource-server",
-            cold_start_delay=0,
-            node_update_interval=1,
-            scheduler_update_interval=1,
-        ),
+        config=WorkcellConfig(data_server_url="http://localhost:8000"),
+    )
+    return WorkcellRedisHandler(
+        workcell_definition=workcell_def, redis_connection=redis_server
     )
 
 
 @pytest.fixture
-def mock_state_handler(mock_workcell_definition: WorkcellDefinition) -> MagicMock:
-    """Fixture for a mock WorkcellRedisHandler."""
-    handler = MagicMock(spec=WorkcellRedisHandler)
-    handler._workcell_definition = mock_workcell_definition
-    handler.get_workcell_definition.return_value = mock_workcell_definition
-    handler.get_node.return_value = Node(
-        node_url="http://node-url",
-        info=NodeInfo(
-            node_name="Test Node",
-            module_name="test_module",
-        ),
-    )
-    handler.get_workflows.return_value = {}
-    handler.has_state_changed.return_value = False
-    handler.shutdown = False
-    handler.paused = False
-    return handler
+def engine(state_handler: WorkcellRedisHandler) -> Engine:
+    """Fixture for creating an Engine instance."""
+    return Engine(state_handler=state_handler)
 
 
-@pytest.fixture
-def engine(mock_state_handler: MagicMock) -> Engine:
-    """Fixture for the Engine instance."""
-    with patch(
-        "madsci.workcell_manager.workcell_engine.importlib.import_module"
-    ) as mock_import:
-        mock_import.return_value.Scheduler = MagicMock()
-        return Engine(mock_state_handler)
-
-
-def test_engine_initialization(engine: Engine, mock_state_handler: MagicMock) -> None:
+def test_engine_initialization(engine: Engine) -> None:
     """Test the initialization of the Engine."""
-    assert engine.state_handler == mock_state_handler
-    assert engine.logger is not None
-    assert engine.data_client is not None
-    assert engine.resource_client is not None
-    assert engine.scheduler is not None
+    assert engine.state_handler is not None
+    assert engine.workcell_definition.workcell_name == "Test Workcell"
 
 
-def test_run_next_step_no_ready_workflows(
-    engine: Engine, mock_state_handler: MagicMock
-) -> None:
+def test_run_next_step_no_ready_workflows(engine: Engine) -> None:
     """Test run_next_step when no workflows are ready."""
-    mock_state_handler.get_workflows.return_value = {}
-    engine.run_next_step()
-    mock_state_handler.set_workflow.assert_not_called()
+    workflow = engine.run_next_step()
+    assert workflow is None
 
 
 def test_run_next_step_with_ready_workflow(
-    engine: Engine, mock_state_handler: MagicMock
+    engine: Engine, state_handler: WorkcellRedisHandler
 ) -> None:
     """Test run_next_step with a ready workflow."""
     workflow = Workflow(
         name="Test Workflow",
-        steps=[],
-        scheduler_metadata=MagicMock(ready_to_run=True, priority=1),
+        steps=[Step(name="Test Step", action="test_action", node="test_node", args={})],
+        scheduler_metadata=SchedulerMetadata(ready_to_run=True, priority=1),
         step_index=0,
         status=WorkflowStatus.QUEUED,
     )
-    mock_state_handler.get_workflows.return_value = {workflow.workflow_id: workflow}
-    engine.run_next_step()
-    assert workflow.status == WorkflowStatus.RUNNING
-    mock_state_handler.set_workflow.assert_called_once_with(workflow)
+    state_handler.set_workflow(workflow)
+    state_handler.update_workflow_queue()
+    with patch(
+        "madsci.workcell_manager.workcell_engine.Engine.run_step"
+    ) as mock_run_step:
+        assert engine.run_next_step() is not None
+        mock_run_step.assert_called_once()
+    updated_workflow = state_handler.get_workflow(workflow.workflow_id)
+    assert updated_workflow.status == WorkflowStatus.RUNNING
 
 
-def test_run_step(engine: Engine, mock_state_handler: MagicMock) -> None:
+def test_run_single_step(engine: Engine, state_handler: WorkcellRedisHandler) -> None:
     """Test running a step in a workflow."""
     step = Step(name="Test Step 1", action="test_action", node="node1", args={})
     workflow = Workflow(
@@ -112,7 +98,18 @@ def test_run_step(engine: Engine, mock_state_handler: MagicMock) -> None:
         status=WorkflowStatus.RUNNING,
         ownership_info=OwnershipInfo(),
     )
-    mock_state_handler.get_workflow.return_value = workflow
+    state_handler.set_workflow(workflow)
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
+        ),
+    )
     with patch(
         "madsci.workcell_manager.workcell_engine.find_node_client"
     ) as mock_client:
@@ -121,16 +118,59 @@ def test_run_step(engine: Engine, mock_state_handler: MagicMock) -> None:
         )
         thread = engine.run_step(workflow.workflow_id)
         thread.join()
-        step = mock_state_handler.set_workflow.call_args[0][0].steps[0]
-        assert step.start_time is not None
-        assert step.end_time is not None
-        assert step.status == ActionStatus.SUCCEEDED
-        assert step.result is not None
-        assert step.result.status == ActionStatus.SUCCEEDED
-        mock_state_handler.set_workflow.assert_called()
+        updated_workflow = state_handler.get_workflow(workflow.workflow_id)
+        assert updated_workflow.steps[0].status == ActionStatus.SUCCEEDED
+        assert updated_workflow.steps[0].result.status == ActionStatus.SUCCEEDED
+        assert updated_workflow.step_index == 0
+        assert updated_workflow.status == WorkflowStatus.COMPLETED
+        assert updated_workflow.end_time is not None
 
 
-def test_finalize_step_success(engine: Engine, mock_state_handler: MagicMock) -> None:
+def test_run_single_step_of_workflow_with_multiple_steps(
+    engine: Engine, state_handler: WorkcellRedisHandler
+) -> None:
+    """Test running a step in a workflow with multiple steps."""
+    step1 = Step(name="Test Step 1", action="test_action", node="node1", args={})
+    step2 = Step(name="Test Step 2", action="test_action", node="node1", args={})
+    workflow = Workflow(
+        name="Test Workflow",
+        steps=[step1, step2],
+        step_index=0,
+        status=WorkflowStatus.RUNNING,
+        ownership_info=OwnershipInfo(),
+    )
+    state_handler.set_workflow(workflow)
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
+        ),
+    )
+    with patch(
+        "madsci.workcell_manager.workcell_engine.find_node_client"
+    ) as mock_client:
+        mock_client.return_value.send_action.return_value = ActionResult(
+            status=ActionStatus.SUCCEEDED
+        )
+        thread = engine.run_step(workflow.workflow_id)
+        thread.join()
+        updated_workflow = state_handler.get_workflow(workflow.workflow_id)
+        assert updated_workflow.steps[0].status == ActionStatus.SUCCEEDED
+        assert updated_workflow.steps[0].result.status == ActionStatus.SUCCEEDED
+        assert updated_workflow.steps[1].status == ActionStatus.NOT_STARTED
+        assert updated_workflow.steps[1].result is None
+        assert updated_workflow.step_index == 1
+        assert updated_workflow.status == WorkflowStatus.IN_PROGRESS
+
+
+def test_finalize_step_success(
+    engine: Engine, state_handler: WorkcellRedisHandler
+) -> None:
     """Test finalizing a successful step."""
     step = Step(name="Test Step 1", action="test_action", node="node1", args={})
     workflow = Workflow(
@@ -139,21 +179,22 @@ def test_finalize_step_success(engine: Engine, mock_state_handler: MagicMock) ->
         step_index=0,
         status=WorkflowStatus.RUNNING,
     )
-    mock_state_handler.get_workflow.return_value = workflow
+    state_handler.set_workflow(workflow)
     updated_step = copy.deepcopy(step)
     updated_step.status = ActionStatus.SUCCEEDED
     updated_step.result = ActionSucceeded()
 
     engine.finalize_step(workflow.workflow_id, updated_step)
 
-    assert mock_state_handler.set_workflow.call_count == 1
-    finalized_workflow = mock_state_handler.set_workflow.call_args[0][0]
+    finalized_workflow = state_handler.get_workflow(workflow.workflow_id)
     assert finalized_workflow.status == WorkflowStatus.COMPLETED
     assert finalized_workflow.end_time is not None
     assert finalized_workflow.steps[0].status == ActionStatus.SUCCEEDED
 
 
-def test_finalize_step_failure(engine: Engine, mock_state_handler: MagicMock) -> None:
+def test_finalize_step_failure(
+    engine: Engine, state_handler: WorkcellRedisHandler
+) -> None:
     """Test finalizing a failed step."""
     step = Step(name="Test Step 1", action="test_action", node="node1", args={})
     workflow = Workflow(
@@ -162,20 +203,22 @@ def test_finalize_step_failure(engine: Engine, mock_state_handler: MagicMock) ->
         step_index=0,
         status=WorkflowStatus.RUNNING,
     )
-    mock_state_handler.get_workflow.return_value = workflow
+    state_handler.set_workflow(workflow)
     updated_step = copy.deepcopy(step)
     updated_step.status = ActionStatus.FAILED
     updated_step.result = ActionFailed()
 
     engine.finalize_step(workflow.workflow_id, updated_step)
 
-    finalized_workflow = mock_state_handler.set_workflow.call_args[0][0]
+    finalized_workflow = state_handler.get_workflow(workflow.workflow_id)
     assert finalized_workflow.status == WorkflowStatus.FAILED
     assert finalized_workflow.end_time is not None
     assert finalized_workflow.steps[0].status == ActionStatus.FAILED
 
 
-def test_handle_data_and_files_with_data(engine: Engine) -> None:
+def test_handle_data_and_files_with_data(
+    engine: Engine, state_handler: WorkcellRedisHandler
+) -> None:
     """Test handle_data_and_files with data points."""
     step = Step(
         name="Test Step",
@@ -190,6 +233,17 @@ def test_handle_data_and_files_with_data(engine: Engine) -> None:
         step_index=0,
         status=WorkflowStatus.RUNNING,
     )
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
+        ),
+    )
     action_result = ActionSucceeded(data={"key1": 42})
 
     with patch.object(engine.data_client, "submit_datapoint") as mock_submit:
@@ -202,7 +256,9 @@ def test_handle_data_and_files_with_data(engine: Engine) -> None:
         assert submitted_datapoint.value == 42
 
 
-def test_handle_data_and_files_with_files(engine: Engine) -> None:
+def test_handle_data_and_files_with_files(
+    engine: Engine, state_handler: WorkcellRedisHandler
+) -> None:
     """Test handle_data_and_files with file points."""
     step = Step(
         name="Test Step",
@@ -216,6 +272,17 @@ def test_handle_data_and_files_with_files(engine: Engine) -> None:
         steps=[step],
         step_index=0,
         status=WorkflowStatus.RUNNING,
+    )
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
+        ),
     )
     action_result = ActionSucceeded(files={"file1": "/path/to/file"})
 
@@ -233,7 +300,7 @@ def test_handle_data_and_files_with_files(engine: Engine) -> None:
 
 
 def test_run_step_send_action_exception_then_get_action_result_success(
-    engine: Engine, mock_state_handler: MagicMock
+    engine: Engine, state_handler: WorkcellRedisHandler
 ) -> None:
     """Test run_step where send_action raises an exception but get_action_result succeeds."""
     step = Step(name="Test Step 1", action="test_action", node="node1", args={})
@@ -244,13 +311,16 @@ def test_run_step_send_action_exception_then_get_action_result_success(
         status=WorkflowStatus.RUNNING,
         ownership_info=OwnershipInfo(),
     )
-    mock_state_handler.get_workflow.return_value = workflow
-    mock_state_handler.get_node.return_value = Node(
-        node_url="http://node-url",
-        info=NodeInfo(
-            node_name="Test Node",
-            module_name="test_module",
-            capabilities=NodeCapabilities(get_action_result=True),
+    state_handler.set_workflow(workflow)
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
         ),
     )
 
@@ -267,7 +337,9 @@ def test_run_step_send_action_exception_then_get_action_result_success(
         thread = engine.run_step(workflow.workflow_id)
         thread.join()
 
-        step = mock_state_handler.set_workflow.call_args[0][0].steps[0]
+        # TODO
+        updated_workflow = state_handler.get_workflow(workflow.workflow_id)
+        step = updated_workflow.steps[0]
         assert step.status == ActionStatus.SUCCEEDED
         assert step.result is not None
         assert step.result.status == ActionStatus.SUCCEEDED
@@ -275,7 +347,7 @@ def test_run_step_send_action_exception_then_get_action_result_success(
 
 
 def test_run_step_send_action_and_get_action_result_fail(
-    engine: Engine, mock_state_handler: MagicMock
+    engine: Engine, state_handler: WorkcellRedisHandler
 ) -> None:
     """Test run_step where both send_action and get_action_result fail."""
     step = Step(name="Test Step 1", action="test_action", node="node1", args={})
@@ -286,13 +358,16 @@ def test_run_step_send_action_and_get_action_result_fail(
         status=WorkflowStatus.RUNNING,
         ownership_info=OwnershipInfo(),
     )
-    mock_state_handler.get_workflow.return_value = workflow
-    mock_state_handler.get_node.return_value = Node(
-        node_url="http://node-url",
-        info=NodeInfo(
-            node_name="Test Node",
-            module_name="test_module",
-            capabilities=NodeCapabilities(get_action_result=True),
+    state_handler.set_workflow(workflow)
+    state_handler.set_node(
+        node_name="node1",
+        node=Node(
+            node_url="http://node-url",
+            info=NodeInfo(
+                node_name="Test Node",
+                module_name="test_module",
+                capabilities=NodeCapabilities(get_action_result=True),
+            ),
         ),
     )
 
@@ -309,7 +384,9 @@ def test_run_step_send_action_and_get_action_result_fail(
         thread = engine.run_step(workflow.workflow_id)
         thread.join()
 
-        step = mock_state_handler.set_workflow.call_args[0][0].steps[0]
+        # TODO
+        updated_workflow = state_handler.get_workflow(workflow.workflow_id)
+        step = updated_workflow.steps[0]
         assert step.status == ActionStatus.UNKNOWN
         assert step.result.status == ActionStatus.UNKNOWN
         mock_client.return_value.get_action_result.assert_called()

--- a/src/madsci_workcell_manager/tests/test_workcell_engine.py
+++ b/src/madsci_workcell_manager/tests/test_workcell_engine.py
@@ -1,0 +1,138 @@
+"""Automated unit tests for the Workcell Engine, using pytest."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from madsci.common.types.action_types import ActionResult, ActionStatus
+from madsci.common.types.step_types import Step
+from madsci.common.types.workcell_types import WorkcellConfig, WorkcellDefinition
+from madsci.common.types.workflow_types import Workflow, WorkflowStatus
+from madsci.workcell_manager.redis_handler import WorkcellRedisHandler
+from madsci.workcell_manager.workcell_engine import Engine
+
+
+@pytest.fixture
+def mock_workcell_definition() -> WorkcellDefinition:
+    """Fixture for a mock WorkcellDefinition."""
+    return WorkcellDefinition(
+        workcell_name="Test Workcell",
+        config=WorkcellConfig(
+            clear_workflows=True,
+            scheduler="madsci.workcell_manager.scheduler",
+            data_server_url="http://data-server",
+            resource_server_url="http://resource-server",
+            cold_start_delay=0,
+            node_update_interval=1,
+            scheduler_update_interval=1,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_state_handler() -> MagicMock:
+    """Fixture for a mock WorkcellRedisHandler."""
+    handler = MagicMock(spec=WorkcellRedisHandler)
+    handler.get_all_workflows.return_value = {}
+    handler.has_state_changed.return_value = False
+    handler.shutdown = False
+    handler.paused = False
+    return handler
+
+
+@pytest.fixture
+def engine(
+    mock_workcell_definition: WorkcellDefinition, mock_state_handler: MagicMock
+) -> Engine:
+    """Fixture for the Engine instance."""
+    with patch(
+        "madsci.workcell_manager.workcell_engine.importlib.import_module"
+    ) as mock_import:
+        mock_import.return_value.Scheduler = MagicMock()
+        return Engine(mock_workcell_definition, mock_state_handler)
+
+
+def test_engine_initialization(engine: Engine, mock_state_handler: MagicMock) -> None:
+    """Test the initialization of the Engine."""
+    mock_state_handler.clear_state.assert_called_once()
+    assert engine.definition.workcell_name == "Test Workcell"
+    assert engine.state_handler == mock_state_handler
+
+
+def test_run_next_step_no_ready_workflows(
+    engine: Engine, mock_state_handler: MagicMock
+) -> None:
+    """Test run_next_step when no workflows are ready."""
+    mock_state_handler.get_all_workflows.return_value = {}
+    engine.run_next_step()
+    mock_state_handler.set_workflow.assert_not_called()
+
+
+def test_run_next_step_with_ready_workflow(
+    engine: Engine, mock_state_handler: MagicMock
+) -> None:
+    """Test run_next_step with a ready workflow."""
+    workflow = Workflow(
+        name="Test Workflow",
+        steps=[],
+        scheduler_metadata=MagicMock(ready_to_run=True, priority=1),
+        step_index=0,
+        status=WorkflowStatus.QUEUED,
+    )
+    mock_state_handler.get_all_workflows.return_value = {workflow.workflow_id: workflow}
+    engine.run_next_step()
+    assert workflow.status == WorkflowStatus.RUNNING
+    mock_state_handler.set_workflow.assert_called_once_with(workflow)
+
+
+def test_run_step(engine: Engine, mock_state_handler: MagicMock) -> None:
+    """Test running a step in a workflow."""
+    step = Step(name="Test Step 1", action="test_action", node="node1", args={})
+    workflow = Workflow(
+        name="Test Workflow",
+        steps=[step],
+        step_index=0,
+        status=WorkflowStatus.RUNNING,
+    )
+    mock_state_handler.get_workflow.return_value = workflow
+    mock_state_handler.get_node.return_value = MagicMock(node_url="http://node-url")
+    with patch(
+        "madsci.workcell_manager.workcell_engine.find_node_client"
+    ) as mock_client:
+        mock_client.return_value.send_action.return_value = ActionResult(
+            action_id="action1", status=ActionStatus.SUCCEEDED
+        )
+        engine.run_step(workflow.workflow_id)
+        assert step.start_time is not None
+        mock_state_handler.set_workflow.assert_called()
+
+
+def test_finalize_step_success(engine: Engine, mock_state_handler: MagicMock) -> None:
+    """Test finalizing a successful step."""
+    step = Step(step_id="step1", status=ActionStatus.SUCCEEDED)
+    workflow = Workflow(
+        workflow_id="wf1",
+        steps=[step],
+        step_index=0,
+        status=WorkflowStatus.RUNNING,
+    )
+    mock_state_handler.get_workflow.return_value = workflow
+    engine.finalize_step("wf1", step)
+    assert workflow.status == WorkflowStatus.COMPLETED
+    assert workflow.end_time is not None
+    mock_state_handler.set_workflow.assert_called_with(workflow)
+
+
+def test_finalize_step_failure(engine: Engine, mock_state_handler: MagicMock) -> None:
+    """Test finalizing a failed step."""
+    step = Step(step_id="step1", status=ActionStatus.FAILED)
+    workflow = Workflow(
+        workflow_id="wf1",
+        steps=[step],
+        step_index=0,
+        status=WorkflowStatus.RUNNING,
+    )
+    mock_state_handler.get_workflow.return_value = workflow
+    engine.finalize_step("wf1", step)
+    assert workflow.status == WorkflowStatus.FAILED
+    assert workflow.end_time is not None
+    mock_state_handler.set_workflow.assert_called_with(workflow)

--- a/src/madsci_workcell_manager/tests/test_workcell_server.py
+++ b/src/madsci_workcell_manager/tests/test_workcell_server.py
@@ -78,7 +78,7 @@ def test_send_admin_command(test_client: TestClient) -> None:
         assert isinstance(response.json(), list)
 
 
-def test_get_all_workflows(test_client: TestClient) -> None:
+def test_get_workflows(test_client: TestClient) -> None:
     """Test the /workflows endpoint."""
     with test_client as client:
         response = client.get("/workflows")

--- a/src/madsci_workcell_manager/tests/test_workcell_server.py
+++ b/src/madsci_workcell_manager/tests/test_workcell_server.py
@@ -57,7 +57,7 @@ def test_add_node(test_client: TestClient) -> None:
         node_name = "test_node"
         node_url = "http://localhost:8000"
         response = client.post(
-            "/nodes/add_node",
+            "/node",
             params={
                 "node_name": node_name,
                 "node_url": node_url,
@@ -68,6 +68,17 @@ def test_add_node(test_client: TestClient) -> None:
         assert response.status_code == 200
         node = Node.model_validate(response.json())
         assert node.node_url == AnyUrl(node_url)
+
+        response = client.get("/node/test_node")
+        assert response.status_code == 200
+        node = Node.model_validate(response.json())
+        assert node.node_url == AnyUrl(node_url)
+
+        response = client.get("/nodes")
+        assert response.status_code == 200
+        assert isinstance(response.json(), dict)
+        assert len(response.json()) == 1
+        assert node_name in response.json()
 
 
 def test_send_admin_command(test_client: TestClient) -> None:


### PR DESCRIPTION
## PR Info

This changes MADSci nodes to run actions as asynchronous by default. Nodes now return ActionRunning by default, with the expectation that users will then query the action result. As a knock on effect:

- Updated the node client with `await_result` tooling and the option to do so automatically
- Refactored the run step command to update the step status as it goes
- Had to revamp various parts of the node module implementation to play nice with this
- Added `ActionStatus.is_terminal` property to easily check whether a given status is terminal or whether we should query for further updates.
- Closes #12
- Closes #20
- Closes #13 

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [ ] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
