### PR TITLE
Location types

### DIFF
--- a/src/madsci_common/madsci/common/types/action_types.py
+++ b/src/madsci_common/madsci/common/types/action_types.py
@@ -7,8 +7,8 @@ from typing import Any, Literal, Optional, Union
 from madsci.common.types.base_types import BaseModel, Error, PathLike, new_ulid_str
 from madsci.common.types.datapoint_types import DataPoint
 from madsci.common.utils import localnow
+from pydantic import Field
 from pydantic.functional_validators import field_validator, model_validator
-from sqlmodel.main import Field
 
 
 class ActionStatus(str, Enum):
@@ -288,19 +288,26 @@ class ActionDefinition(BaseModel):
         description="A description of the action.",
     )
     args: Union[
-        dict[str, "ActionArgumentDefinition"],
-        list["ActionArgumentDefinition"],
+        dict[str, "ArgumentDefinition"],
+        list["ArgumentDefinition"],
     ] = Field(
         title="Action Arguments",
         description="The arguments of the action.",
         default_factory=dict,
     )
-    files: Union[dict[str, "ActionFileDefinition"], list["ActionFileDefinition"]] = (
-        Field(
-            title="Action File Arguments",
-            description="The file arguments of the action.",
-            default_factory=dict,
-        )
+    locations: Union[
+        dict[str, "LocationArgumentDefinition"], list["LocationArgumentDefinition"]
+    ] = Field(
+        title="Action Location Arguments",
+        description="The location arguments of the action.",
+        default_factory=dict,
+    )
+    files: Union[
+        dict[str, "FileArgumentDefinition"], list["FileArgumentDefinition"]
+    ] = Field(
+        title="Action File Arguments",
+        description="The file arguments of the action.",
+        default_factory=dict,
     )
     results: Union[
         dict[str, "ActionResultDefinition"],
@@ -332,6 +339,14 @@ class ActionDefinition(BaseModel):
             return {file.name: file for file in v}
         return v
 
+    @field_validator("locations", mode="after")
+    @classmethod
+    def ensure_locations_are_dict(cls, v: Any) -> Any:
+        """Ensure that the locations are a dictionary"""
+        if isinstance(v, list):
+            return {location.name: location for location in v}
+        return v
+
     @field_validator("results", mode="after")
     @classmethod
     def ensure_results_are_dict(cls, v: Any) -> Any:
@@ -353,10 +368,14 @@ class ActionDefinition(BaseModel):
             if file.name in names:
                 raise ValueError(f"File name '{file.name}' is not unique")
             names.add(file.name)
+        for location in v.locations.values():
+            if location.name in names:
+                raise ValueError(f"Location name '{location.name}' is not unique")
+            names.add(location.name)
         return v
 
 
-class ActionArgumentDefinition(BaseModel):
+class ArgumentDefinition(BaseModel):
     """Defines an argument for a node action"""
 
     name: str = Field(
@@ -367,7 +386,7 @@ class ActionArgumentDefinition(BaseModel):
         title="Argument Description",
         description="A description of the argument.",
     )
-    type: str = Field(
+    argument_type: str = Field(
         title="Argument Type", description="Any type information about the argument"
     )
     required: bool = Field(
@@ -381,20 +400,23 @@ class ActionArgumentDefinition(BaseModel):
     )
 
 
-class ActionFileDefinition(BaseModel):
+class LocationArgumentDefinition(ArgumentDefinition):
+    """Location Argument Definition for use in NodeInfo"""
+
+    argument_type: Literal["location"] = Field(
+        title="Location Argument Type",
+        description="The type of the location argument.",
+        default="location",
+    )
+
+
+class FileArgumentDefinition(ArgumentDefinition):
     """Defines a file for a node action"""
 
-    name: str = Field(
-        title="File Name",
-        description="The name of the file.",
-    )
-    required: bool = Field(
-        title="File Required",
-        description="Whether the file is required.",
-    )
-    description: str = Field(
-        title="File Description",
-        description="A description of the file.",
+    argument_type: Literal["file"] = Field(
+        title="File Argument Type",
+        description="The type of the file argument.",
+        default="file",
     )
 
 

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -75,28 +75,6 @@ class LocationReservation(BaseModel):
         )
 
 
-class LocationArgumentDefinition(BaseModel):
-    """Location Argument Definition for use in NodeInfo"""
-
-    name: str = Field(
-        title="Location Argument Name",
-        description="The name of the location argument.",
-    )
-    description: str = Field(
-        title="Location Argument Description",
-        description="A description of the location argument.",
-    )
-    required: bool = Field(
-        title="Location Argument Required",
-        description="Whether the location argument is required.",
-    )
-    default: Optional[Any] = Field(
-        title="Location Argument Default",
-        description="The default value of the location argument.",
-        default=None,
-    )
-
-
 class LocationArgument(BaseModel):
     """Location Argument to be used by MADSCI nodes."""
 

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -75,8 +75,12 @@ class LocationReservation(BaseModel):
         )
 
 
+class LocationArgumentDefinition(BaseModel):
+    """Location Argument Definition for use in NodeInfo"""
+
+
 class LocationArgument(BaseModel):
-    """Location Argument for MADSCI nodes."""
+    """Location Argument to be used by MADSCI nodes."""
 
     location: Any
     """Details about the Location relevant to this node"""

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -73,3 +73,12 @@ class LocationReservation(BaseModel):
             and self.start <= datetime.now()
             and self.end >= datetime.now()
         )
+
+
+class LocationArgument(BaseModel):
+    """Location Argument for MADSCI nodes."""
+
+    location: Any
+    """Details about the Location relevant to this node"""
+    resource_id: Optional[str] = None
+    """The ID of the corresponding resource, if any"""

--- a/src/madsci_common/madsci/common/types/location_types.py
+++ b/src/madsci_common/madsci/common/types/location_types.py
@@ -78,6 +78,24 @@ class LocationReservation(BaseModel):
 class LocationArgumentDefinition(BaseModel):
     """Location Argument Definition for use in NodeInfo"""
 
+    name: str = Field(
+        title="Location Argument Name",
+        description="The name of the location argument.",
+    )
+    description: str = Field(
+        title="Location Argument Description",
+        description="A description of the location argument.",
+    )
+    required: bool = Field(
+        title="Location Argument Required",
+        description="Whether the location argument is required.",
+    )
+    default: Optional[Any] = Field(
+        title="Location Argument Default",
+        description="The default value of the location argument.",
+        default=None,
+    )
+
 
 class LocationArgument(BaseModel):
     """Location Argument to be used by MADSCI nodes."""

--- a/src/madsci_node_module/madsci/node_module/abstract_node_module.py
+++ b/src/madsci_node_module/madsci/node_module/abstract_node_module.py
@@ -25,12 +25,13 @@ from madsci.common.exceptions import (
     ActionNotImplementedError,
 )
 from madsci.common.types.action_types import (
-    ActionArgumentDefinition,
     ActionDefinition,
-    ActionFileDefinition,
     ActionRequest,
     ActionResult,
     ActionStatus,
+    ArgumentDefinition,
+    FileArgumentDefinition,
+    LocationArgumentDefinition,
 )
 from madsci.common.types.admin_command_types import AdminCommandResponse
 from madsci.common.types.auth_types import OwnershipInfo
@@ -38,7 +39,6 @@ from madsci.common.types.base_types import Error
 from madsci.common.types.event_types import Event, EventClientConfig, EventType
 from madsci.common.types.location_types import (
     LocationArgument,
-    LocationArgumentDefinition,
 )
 from madsci.common.types.node_types import (
     AdminCommands,
@@ -472,80 +472,95 @@ class AbstractNode:
                     and parameter_name not in [file.name for file in action_def.files]
                     and parameter_name != "action"
                 ):
-                    type_hint = parameter_type
-                    description = ""
-                    annotated_as_file = False
-                    annotated_as_arg = False
-                    # * If the type hint is Optional, extract the inner type
-                    if is_optional(type_hint):
-                        type_hint = get_args(type_hint)[0]
-                    # * If the type hint is an Annotated type, extract the type and description
-                    # * Description here means the first string metadata in the Annotated type
-                    if get_origin(type_hint) == Annotated:
-                        description = next(
-                            (
-                                metadata
-                                for metadata in type_hint.__metadata__
-                                if isinstance(metadata, str)
-                            ),
-                            "",
-                        )
-                        annotated_as_file = any(
-                            isinstance(metadata, ActionFileDefinition)
-                            for metadata in type_hint.__metadata__
-                        )
-                        annotated_as_arg = not any(
-                            isinstance(metadata, ActionArgumentDefinition)
-                            for metadata in type_hint.__metadata__
-                        )
-                        if annotated_as_file and annotated_as_arg:
-                            raise ValueError(
-                                f"Parameter '{parameter_name}' is annotated as both a file and an argument. This is not allowed.",
-                            )
-                        type_hint = get_args(type_hint)[0]
-                    # * Another Optional check after Annotated type extraction
-                    if is_optional(type_hint):
-                        type_hint = get_args(type_hint)[0]
-                    # * If the type hint is a file type, add it to the files list
-                    if annotated_as_file or (
-                        getattr(type_hint, "__name__", None)
-                        in ["Path", "PurePath", "PosixPath", "WindowsPath"]
-                        and not annotated_as_arg
-                    ):
-                        # * Add a file parameter to the action
-                        action_def.files[parameter_name] = ActionFileDefinition(
-                            name=parameter_name,
-                            required=True,
-                            description=description,
-                        )
-                    # * Otherwise, add it to the args list
-                    else:
-                        parameter_info = signature.parameters[parameter_name]
-                        # * Add an arg to the action
-                        default = (
-                            None
-                            if parameter_info.default == inspect.Parameter.empty
-                            else parameter_info.default
-                        )
-                        is_required = parameter_info.default == inspect.Parameter.empty
-
-                        if type_hint is LocationArgument:
-                            action_def.args[parameter_name] = (
-                                LocationArgumentDefinition(
-                                    name=parameter_name,
-                                    required=is_required,
-                                    description=description,
-                                )
-                            )
-                        else:
-                            action_def.args[parameter_name] = ActionArgumentDefinition(
-                                name=parameter_name,
-                                type=pretty_type_repr(type_hint),
-                                default=default,
-                                required=is_required,
-                                description=description,
-                            )
+                    self._parse_action_arg(
+                        action_def, signature, parameter_name, parameter_type
+                    )
         self.node_info.actions[action_name] = action_def
+
+    def _parse_action_arg(
+        self,
+        action_def: ActionDefinition,
+        signature: inspect.Signature,
+        parameter_name: str,
+        parameter_type: Any,
+    ) -> None:
+        """Parses a function argument of an action handler into a MADSci ArgumentDefinition"""
+        type_hint = parameter_type
+        description = ""
+        annotated_as_file = False
+        annotated_as_arg = False
+        annotated_as_location = False
+        # * If the type hint is Optional, extract the inner type
+        if is_optional(type_hint):
+            type_hint = get_args(type_hint)[0]
+            # * If the type hint is an Annotated type, extract the type and description
+            # * Description here means the first string metadata in the Annotated type
+        if get_origin(type_hint) == Annotated:
+            description = next(
+                (
+                    metadata
+                    for metadata in type_hint.__metadata__
+                    if isinstance(metadata, str)
+                ),
+                "",
+            )
+            annotated_as_file = any(
+                isinstance(metadata, FileArgumentDefinition)
+                for metadata in type_hint.__metadata__
+            )
+            annotated_as_location = any(
+                isinstance(metadata, LocationArgumentDefinition)
+                for metadata in type_hint.__metadata__
+            )
+            annotated_as_arg = any(
+                isinstance(metadata, ArgumentDefinition)
+                for metadata in type_hint.__metadata__
+            )
+            if sum([annotated_as_file, annotated_as_arg, annotated_as_location]) > 1:
+                raise ValueError(
+                    f"Parameter '{parameter_name}' is annotated as multiple types of argument. This is not allowed.",
+                )
+            type_hint = get_args(type_hint)[0]
+            # * Another Optional check after Annotated type extraction
+        if is_optional(type_hint):
+            type_hint = get_args(type_hint)[0]
+            # * If the type hint is a file type, add it to the files list
+        if annotated_as_file or (
+            getattr(type_hint, "__name__", None)
+            in ["Path", "PurePath", "PosixPath", "WindowsPath"]
+            and not annotated_as_arg
+        ):
+            # * Add a file parameter to the action
+            action_def.files[parameter_name] = FileArgumentDefinition(
+                name=parameter_name,
+                required=True,
+                description=description,
+            )
+        # * Otherwise, add it to the args list
+        else:
+            parameter_info = signature.parameters[parameter_name]
+            # * Add an arg to the action
+            default = (
+                None
+                if parameter_info.default == inspect.Parameter.empty
+                else parameter_info.default
+            )
+            is_required = parameter_info.default == inspect.Parameter.empty
+
+            if annotated_as_location or type_hint is LocationArgument:
+                action_def.locations[parameter_name] = LocationArgumentDefinition(
+                    name=parameter_name,
+                    required=is_required,
+                    description=description,
+                )
+            else:
+                action_def.args[parameter_name] = ArgumentDefinition(
+                    name=parameter_name,
+                    argument_type=pretty_type_repr(type_hint),
+                    default=default,
+                    required=is_required,
+                    description=description,
+                )
 
     def _parse_action_args(
         self,

--- a/src/madsci_node_module/madsci/node_module/abstract_node_module.py
+++ b/src/madsci_node_module/madsci/node_module/abstract_node_module.py
@@ -36,7 +36,10 @@ from madsci.common.types.admin_command_types import AdminCommandResponse
 from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.base_types import Error
 from madsci.common.types.event_types import Event, EventClientConfig, EventType
-from madsci.common.types.location_types import LocationArgument
+from madsci.common.types.location_types import (
+    LocationArgument,
+    LocationArgumentDefinition,
+)
 from madsci.common.types.node_types import (
     AdminCommands,
     NodeClientCapabilities,
@@ -526,13 +529,22 @@ class AbstractNode:
                         )
                         is_required = parameter_info.default == inspect.Parameter.empty
 
-                        action_def.args[parameter_name] = ActionArgumentDefinition(
-                            name=parameter_name,
-                            type=pretty_type_repr(type_hint),
-                            default=default,
-                            required=is_required,
-                            description=description,
-                        )
+                        if type_hint is LocationArgument:
+                            action_def.args[parameter_name] = (
+                                LocationArgumentDefinition(
+                                    name=parameter_name,
+                                    required=is_required,
+                                    description=description,
+                                )
+                            )
+                        else:
+                            action_def.args[parameter_name] = ActionArgumentDefinition(
+                                name=parameter_name,
+                                type=pretty_type_repr(type_hint),
+                                default=default,
+                                required=is_required,
+                                description=description,
+                            )
         self.node_info.actions[action_name] = action_def
 
     def _parse_action_args(

--- a/src/madsci_node_module/tests/test_rest_node_module.py
+++ b/src/madsci_node_module/tests/test_rest_node_module.py
@@ -229,15 +229,19 @@ def test_get_info(test_client: TestClient) -> None:
         assert len(node_info.actions) == 4
         assert node_info.actions["test_action"].description == "A test action."
         assert node_info.actions["test_action"].args["test_param"].required
-        assert node_info.actions["test_action"].args["test_param"].type == "int"
+        assert (
+            node_info.actions["test_action"].args["test_param"].argument_type == "int"
+        )
         assert node_info.actions["test_fail"].description == "A test action that fails."
         assert node_info.actions["test_fail"].args["test_param"].required
-        assert node_info.actions["test_fail"].args["test_param"].type == "int"
+        assert node_info.actions["test_fail"].args["test_param"].argument_type == "int"
         assert (
             node_info.actions["test_optional_param_action"].args["test_param"].required
         )
         assert (
-            node_info.actions["test_optional_param_action"].args["test_param"].type
+            node_info.actions["test_optional_param_action"]
+            .args["test_param"]
+            .argument_type
             == "int"
         )
         assert (
@@ -246,7 +250,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_optional_param_action"].args["optional_param"].type
+            node_info.actions["test_optional_param_action"]
+            .args["optional_param"]
+            .argument_type
             == "str"
         )
         assert (
@@ -259,7 +265,8 @@ def test_get_info(test_client: TestClient) -> None:
             not node_info.actions["test_annotation_action"].args["test_param"].required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param"].type == "int"
+            node_info.actions["test_annotation_action"].args["test_param"].argument_type
+            == "int"
         )
         assert (
             node_info.actions["test_annotation_action"].args["test_param"].description
@@ -271,7 +278,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param_2"].type
+            node_info.actions["test_annotation_action"]
+            .args["test_param_2"]
+            .argument_type
             == "int"
         )
         assert (
@@ -284,7 +293,9 @@ def test_get_info(test_client: TestClient) -> None:
             .required
         )
         assert (
-            node_info.actions["test_annotation_action"].args["test_param_3"].type
+            node_info.actions["test_annotation_action"]
+            .args["test_param_3"]
+            .argument_type
             == "int"
         )
         assert (

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
@@ -13,6 +13,7 @@ from madsci.client.event_client import default_logger
 from madsci.client.node.abstract_node_client import AbstractNodeClient
 from madsci.common.types.action_types import ActionRequest, ActionResult
 from madsci.common.types.datapoint_types import FileDataPoint, ValueDataPoint
+from madsci.common.types.location_types import LocationArgument
 from madsci.common.types.node_types import Node
 from madsci.common.types.step_types import Step
 from madsci.common.types.workcell_types import WorkcellDefinition
@@ -148,9 +149,18 @@ class Engine:
         client = find_node_client(node.node_url)
         response = None
         try:
+            location_args = {}
+            for key, location in step.locations.items():
+                location_payload = location.lookup
+                location_args[key] = LocationArgument(
+                    location=location_payload, resource_id=location.resource_id
+                )
+
+            # Merge with step.args
+            args = {**step.args, **location_args}
             request = ActionRequest(
                 action_name=step.action,
-                args={**step.args, **step.locations},
+                args=args,
                 files=step.files,
             )
             response = client.send_action(request)

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workflow_utils.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workflow_utils.py
@@ -31,15 +31,16 @@ def validate_node_names(workflow: Workflow, workcell: WorkcellDefinition) -> Non
 
 def validate_step(step: Step, state_handler: WorkcellRedisHandler) -> tuple[bool, str]:
     """Check if a step is valid based on the node's info"""
+    result = (False, "Unknown validation error")
     if step.node in state_handler.get_all_nodes():
         node = state_handler.get_node(step.node)
         info = node.info
         if info is None:
-            return (
+            result = (
                 True,
                 f"Node {step.node} didn't return proper about information, skipping validation",
             )
-        if step.action in info.actions:
+        elif step.action in info.actions:
             action = info.actions[step.action]
             for action_arg in action.args.values():
                 if action_arg.name not in step.args and action_arg.required:
@@ -48,22 +49,33 @@ def validate_step(step: Step, state_handler: WorkcellRedisHandler) -> tuple[bool
                         f"Step '{step.name}': Node {step.node}'s action, '{step.action}', is missing arg '{action_arg.name}'",
                     )
                 # TODO: Action arg type validation goes here
+            for action_location in action.locations:
+                if (
+                    action_location.name not in step.locations
+                    and action_location.required
+                ):
+                    return (
+                        False,
+                        f"Step '{step.name}': Node {step.node}'s action, '{step.action}', is missing location '{action_location.name}'",
+                    )
             for action_file in action.files:
                 if action_file.name not in step.files and action_file.required:
                     return (
                         False,
                         f"Step '{step.name}': Node {step.node}'s action, '{step.action}', is missing file '{action_file.name}'",
                     )
-            return True, f"Step '{step.name}': Validated successfully"
-
-        return (
+            result = (True, f"Step '{step.name}': Validated successfully")
+        else:
+            result = (
+                False,
+                f"Step '{step.name}': Node {step.node} has no action '{step.action}'",
+            )
+    else:
+        result = (
             False,
-            f"Step '{step.name}': Node {step.node} has no action '{step.action}'",
+            f"Step '{step.name}': Node {step.node} is not defined in workcell",
         )
-    return (
-        False,
-        f"Step '{step.name}': Node {step.node} is not defined in workcell",
-    )
+    return result
 
 
 def create_workflow(


### PR DESCRIPTION
## PR Info

This PR enhances support for LocationArgument in node actions and workcell communication.

- Adds new `LocationArgument` and `LocationArgumentDefinition` dataclasses to support structured location inputs in actions.
- Ensures that if an action function declares a parameter as `LocationArgument`, any dict passed via the API is validated and reconstructed using `LocationArgument.model_validate`.
- Updates `run_step` in the `workcell engine` to construct and pass `LocationArgument` objects using `Location.lookup` and `resource_id` before sending the action request to the node.
- Detects `LocationArgument` type hints in `_add_action` and registers them as `LocationArgumentDefinition` in `NodeInfo`.
- Closes #24 

## Developer Checklists

I have:

- [ ] Run Pre-commit and Unit Tests, and ensured that they pass
- [ ] Created or updated documentation relevant to your change
- [ ] Created or updated unit tests relevant to your change
