### PR TITLE
Fix: workcell_cli.py Create Function

### DIFF
--- a/src/madsci_client/madsci/client/cli/workcell_cli.py
+++ b/src/madsci_client/madsci/client/cli/workcell_cli.py
@@ -122,7 +122,7 @@ def create(
         else prompt_for_input("Workcell Description", quiet=ctx.obj.quiet)
     )
 
-    workcell = WorkcellDefinition(name=name, description=description)
+    workcell = WorkcellDefinition(workcell_name=name, description=description)
     console.print(workcell)
 
     path = path if path else ctx.parent.params.get("path")


### PR DESCRIPTION
## PR Info

Changed the CLI creation logic to pass `workcell_name=name` instead of `name=name`, since the `WorkcellDefinition` model requires a field named `workcell_name` (not `name`). As a result, now the `madsci workcell create` command works as intended.

## Developer Checklists

I have:

- [X ] Run Pre-commit and Unit Tests, and ensured that they pass (Pre-commits passed, Unit Tests 42 passed, 6 skipped, 188 errors due to improper development environment)
- [] Created or updated documentation relevant to your change (unnecessary, too minor of a fix)
- [] Created or updated unit tests relevant to your change (unnecessary, too minor of a fix)

## Notes

Apologies on not being able to run the Unit Tests perfectly, but for such a minor fix, I figured it wouldn't change the current, main branch, Unit Test results.

Since it's my first time suggesting changes, any extra information on setting up a proper development environment for running these tests would be great, as I'd love to make sure I can confidently say they all passed if I suggest another fix.