### PR TITLE
Fix #159, bump to v0.5.1

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -105,3 +105,76 @@ down:
 # Alias for docker compose
 dc *args:
   @docker compose {{args}}
+
+# Update version across all pyproject.toml and package.json files
+update-version version:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  # Validate version format (basic semver check)
+  if ! echo "{{version}}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+    echo "❌ Error: Version '{{version}}' is not a valid semantic version (e.g., 1.0.0, 1.0.0-rc.1)"
+    exit 1
+  fi
+
+  echo "📦 Updating version to {{version}} across all files..."
+
+  # Store current version for comparison
+  current_version=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+  echo "   Current version: $current_version"
+  echo "   New version: {{version}}"
+
+  if [ "$current_version" = "{{version}}" ]; then
+    echo "ℹ️  Version is already {{version}}, no changes needed"
+    exit 0
+  fi
+
+  # Update root pyproject.toml
+  sed -i.bak 's/^version = ".*"/version = "{{version}}"/' pyproject.toml
+
+  # Update all Python package pyproject.toml files
+  find src -name "pyproject.toml" -exec sed -i.bak 's/^version = ".*"/version = "{{version}}"/' {} \;
+
+  # Update UI package.json
+  if [ -f ui/package.json ]; then
+    sed -i.bak 's/"version": ".*"/"version": "{{version}}"/' ui/package.json
+  fi
+
+  # Clean up backup files
+  find . -name "*.bak" -delete
+
+  echo "✅ Updated version to {{version}} in:"
+  echo "  - Root pyproject.toml"
+  echo "  - All Python package pyproject.toml files ($(find src -name "pyproject.toml" | wc -l | xargs echo) files)"
+  echo "  - UI package.json"
+  echo ""
+
+  # Show changed files if in git repo
+  if git rev-parse --git-dir > /dev/null 2>&1; then
+    changed_files=$(git diff --name-only | grep -E "(pyproject\.toml|package\.json)" | head -20 || true)
+    if [ -n "$changed_files" ]; then
+      echo "📝 Files updated:"
+      echo "$changed_files" | sed 's/^/  - /'
+    fi
+  fi
+
+# Show current version across all files
+show-version:
+  #!/usr/bin/env bash
+  echo "📦 Current versions across the repository:"
+  echo ""
+  echo "Root:"
+  echo "  - pyproject.toml: $(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')"
+  echo ""
+  echo "Python packages:"
+  find src -name "pyproject.toml" | sort | while read file; do
+    version=$(grep '^version = ' "$file" | sed 's/version = "\(.*\)"/\1/')
+    package_name=$(grep '^name = ' "$file" | sed 's/name = "\(.*\)"/\1/')
+    echo "  - $package_name: $version"
+  done
+  echo ""
+  if [ -f ui/package.json ]; then
+    echo "UI:"
+    ui_version=$(grep '"version":' ui/package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+    echo "  - package.json: $ui_version"
+  fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = ["pre-commit>=4.3.0"]
 readme="README.md"
 requires-python = ">=3.9.1"

--- a/src/madsci_client/pyproject.toml
+++ b/src/madsci_client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.client"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Python Client and CLI."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_common/pyproject.toml
+++ b/src/madsci_common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.common"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Common Definitions and Utilities."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_data_manager/pyproject.toml
+++ b/src/madsci_data_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.data_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Data Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_event_manager/pyproject.toml
+++ b/src/madsci_event_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.event_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Event and Logging Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_experiment_application/pyproject.toml
+++ b/src/madsci_experiment_application/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.experiment_application"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Experiment Application framework."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_experiment_manager/pyproject.toml
+++ b/src/madsci_experiment_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.experiment_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Experiment Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_location_manager/pyproject.toml
+++ b/src/madsci_location_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.location_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Location Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_node_module/madsci/node_module/abstract_node_module.py
+++ b/src/madsci_node_module/madsci/node_module/abstract_node_module.py
@@ -475,6 +475,28 @@ class AbstractNode:
 
         return False
 
+    def _contains_location_argument(self, type_hint: Any) -> bool:
+        """Check if a type hint contains LocationArgument either directly or within a Union.
+
+        Args:
+            type_hint: The type hint to check (after extracting from Annotated/Optional)
+
+        Returns:
+            True if the type is LocationArgument or a Union containing LocationArgument
+        """
+        # Direct LocationArgument type
+        if type_hint is LocationArgument:
+            return True
+
+        # Check for Union types that contain LocationArgument
+        origin = get_origin(type_hint)
+        if origin is Union:
+            args = get_args(type_hint)
+            # Check if any of the Union arguments is LocationArgument
+            return any(arg is LocationArgument for arg in args)
+
+        return False
+
     def _parse_action_arg(
         self,
         action_def: ActionDefinition,
@@ -543,7 +565,7 @@ class AbstractNode:
             )
             is_required = parameter_info.default == inspect.Parameter.empty
 
-            if annotated_as_location or type_hint is LocationArgument:
+            if annotated_as_location or self._contains_location_argument(type_hint):
                 action_def.locations[parameter_name] = LocationArgumentDefinition(
                     name=parameter_name,
                     required=is_required,

--- a/src/madsci_node_module/madsci/node_module/abstract_node_module.py
+++ b/src/madsci_node_module/madsci/node_module/abstract_node_module.py
@@ -479,7 +479,8 @@ class AbstractNode:
         """Check if a type hint contains LocationArgument either directly or within a Union.
 
         Args:
-            type_hint: The type hint to check (after extracting from Annotated/Optional)
+            type_hint: The type hint to check. Caller must unwrap Optional and Annotated types
+                      before calling this method.
 
         Returns:
             True if the type is LocationArgument or a Union containing LocationArgument

--- a/src/madsci_node_module/pyproject.toml
+++ b/src/madsci_node_module/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "madsci.node_module"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Node Module Helper Classes."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_node_module/tests/test_node_infrastructure.py
+++ b/src/madsci_node_module/tests/test_node_infrastructure.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from typing import Annotated, Optional, Union, get_type_hints
 
+import pytest
 from fastapi.testclient import TestClient
 from madsci.client.data_client import DataClient
 from madsci.client.event_client import EventClient
@@ -38,6 +39,37 @@ from madsci_node_module.tests.test_rest_utils import (
     parametrize_admin_commands,
     validate_admin_command_response,
 )
+
+
+@pytest.fixture
+def dummy_node():
+    """Create a DummyNode instance for testing."""
+
+    class DummyNode(AbstractNode):
+        __test__ = False
+        config_model = TestNodeConfig
+
+        def __init__(self):
+            """Initialize without calling parent __init__ to avoid file dependencies."""
+            self.config = TestNodeConfig(test_required_param=42)
+            self.node_definition = NodeDefinition(
+                node_name="test_node",
+                node_id=new_ulid_str(),
+                module_name="test_module",
+                module_version="0.0.1",
+            )
+            self.node_info = NodeInfo.from_node_def_and_config(
+                self.node_definition, self.config
+            )
+            self.action_handlers = {}
+            self.action_history = {}
+            self.node_state = {}
+            self.logger = self.event_client = EventClient()
+            self.resource_client = ResourceClient(event_client=self.event_client)
+            self.data_client = DataClient()
+            self.node_status = NodeStatus(ready=True)
+
+    return DummyNode()
 
 
 class TestNodeLifecycle:
@@ -876,7 +908,7 @@ class TestAnnotatedPathInNode:
 class TestLocationArgumentDetection:
     """Test that Union types containing LocationArgument are properly detected as location arguments."""
 
-    def test_union_location_argument_detection(self) -> None:
+    def test_union_location_argument_detection(self, dummy_node) -> None:
         """Test that Union[LocationArgument, str] is properly detected as a location argument."""
         # Create test action definition
         action_def = ActionDefinition(
@@ -885,33 +917,6 @@ class TestLocationArgumentDetection:
             blocking=False,
         )
 
-        # Create a dummy node
-        class DummyNode(AbstractNode):
-            __test__ = False
-            config_model = TestNodeConfig
-
-            def __init__(self):
-                """Initialize without calling parent __init__ to avoid file dependencies."""
-                self.config = TestNodeConfig(test_required_param=42)
-                self.node_definition = NodeDefinition(
-                    node_name="test_node",
-                    node_id=new_ulid_str(),
-                    module_name="test_module",
-                    module_version="0.0.1",
-                )
-                self.node_info = NodeInfo.from_node_def_and_config(
-                    self.node_definition, self.config
-                )
-                self.action_handlers = {}
-                self.action_history = {}
-                self.node_state = {}
-                self.logger = self.event_client = EventClient()
-                self.resource_client = ResourceClient(event_client=self.event_client)
-                self.data_client = DataClient()
-                self.node_status = NodeStatus(ready=True)
-
-        node = DummyNode()
-
         # Simulate a function signature with Union[LocationArgument, str]
         def test_func(target: Union[LocationArgument, str] = "default"):
             pass
@@ -919,7 +924,9 @@ class TestLocationArgumentDetection:
         signature = inspect.signature(test_func)
         type_hints = get_type_hints(test_func, include_extras=True)
 
-        node._parse_action_arg(action_def, signature, "target", type_hints["target"])
+        dummy_node._parse_action_arg(
+            action_def, signature, "target", type_hints["target"]
+        )
 
         # BUG: This currently fails because Union[LocationArgument, str] is not detected as location
         # The parameter gets added to args instead of locations
@@ -931,7 +938,7 @@ class TestLocationArgumentDetection:
         )
         assert isinstance(action_def.locations["target"], LocationArgumentDefinition)
 
-    def test_optional_location_argument_detection(self) -> None:
+    def test_optional_location_argument_detection(self, dummy_node) -> None:
         """Test that Optional[LocationArgument] is properly detected as a location argument."""
         # Create test action definition
         action_def = ActionDefinition(
@@ -940,33 +947,6 @@ class TestLocationArgumentDetection:
             blocking=False,
         )
 
-        # Create a dummy node
-        class DummyNode(AbstractNode):
-            __test__ = False
-            config_model = TestNodeConfig
-
-            def __init__(self):
-                """Initialize without calling parent __init__ to avoid file dependencies."""
-                self.config = TestNodeConfig(test_required_param=42)
-                self.node_definition = NodeDefinition(
-                    node_name="test_node",
-                    node_id=new_ulid_str(),
-                    module_name="test_module",
-                    module_version="0.0.1",
-                )
-                self.node_info = NodeInfo.from_node_def_and_config(
-                    self.node_definition, self.config
-                )
-                self.action_handlers = {}
-                self.action_history = {}
-                self.node_state = {}
-                self.logger = self.event_client = EventClient()
-                self.resource_client = ResourceClient(event_client=self.event_client)
-                self.data_client = DataClient()
-                self.node_status = NodeStatus(ready=True)
-
-        node = DummyNode()
-
         # Simulate a function signature with Optional[LocationArgument]
         def test_func(target: Optional[LocationArgument] = None):
             pass
@@ -974,7 +954,9 @@ class TestLocationArgumentDetection:
         signature = inspect.signature(test_func)
         type_hints = get_type_hints(test_func, include_extras=True)
 
-        node._parse_action_arg(action_def, signature, "target", type_hints["target"])
+        dummy_node._parse_action_arg(
+            action_def, signature, "target", type_hints["target"]
+        )
 
         # BUG: This currently fails because Optional[LocationArgument] is not detected as location
         # after the Optional unwrapping, the type check fails
@@ -986,7 +968,7 @@ class TestLocationArgumentDetection:
         )
         assert isinstance(action_def.locations["target"], LocationArgumentDefinition)
 
-    def test_complex_union_location_argument_detection(self) -> None:
+    def test_complex_union_location_argument_detection(self, dummy_node) -> None:
         """Test that Union[str, LocationArgument, int] is properly detected as a location argument."""
         # Create test action definition
         action_def = ActionDefinition(
@@ -995,33 +977,6 @@ class TestLocationArgumentDetection:
             blocking=False,
         )
 
-        # Create a dummy node
-        class DummyNode(AbstractNode):
-            __test__ = False
-            config_model = TestNodeConfig
-
-            def __init__(self):
-                """Initialize without calling parent __init__ to avoid file dependencies."""
-                self.config = TestNodeConfig(test_required_param=42)
-                self.node_definition = NodeDefinition(
-                    node_name="test_node",
-                    node_id=new_ulid_str(),
-                    module_name="test_module",
-                    module_version="0.0.1",
-                )
-                self.node_info = NodeInfo.from_node_def_and_config(
-                    self.node_definition, self.config
-                )
-                self.action_handlers = {}
-                self.action_history = {}
-                self.node_state = {}
-                self.logger = self.event_client = EventClient()
-                self.resource_client = ResourceClient(event_client=self.event_client)
-                self.data_client = DataClient()
-                self.node_status = NodeStatus(ready=True)
-
-        node = DummyNode()
-
         # Simulate a function signature with Union[str, LocationArgument, int]
         def test_func(target: Union[str, LocationArgument, int] = "default"):
             pass
@@ -1029,7 +984,9 @@ class TestLocationArgumentDetection:
         signature = inspect.signature(test_func)
         type_hints = get_type_hints(test_func, include_extras=True)
 
-        node._parse_action_arg(action_def, signature, "target", type_hints["target"])
+        dummy_node._parse_action_arg(
+            action_def, signature, "target", type_hints["target"]
+        )
 
         # Should be detected as a location argument because Union contains LocationArgument
         assert "target" in action_def.locations, (
@@ -1040,7 +997,7 @@ class TestLocationArgumentDetection:
         )
         assert isinstance(action_def.locations["target"], LocationArgumentDefinition)
 
-    def test_union_without_location_argument(self) -> None:
+    def test_union_without_location_argument(self, dummy_node) -> None:
         """Test that Union[str, int] without LocationArgument is NOT detected as a location argument."""
         # Create test action definition
         action_def = ActionDefinition(
@@ -1049,33 +1006,6 @@ class TestLocationArgumentDetection:
             blocking=False,
         )
 
-        # Create a dummy node
-        class DummyNode(AbstractNode):
-            __test__ = False
-            config_model = TestNodeConfig
-
-            def __init__(self):
-                """Initialize without calling parent __init__ to avoid file dependencies."""
-                self.config = TestNodeConfig(test_required_param=42)
-                self.node_definition = NodeDefinition(
-                    node_name="test_node",
-                    node_id=new_ulid_str(),
-                    module_name="test_module",
-                    module_version="0.0.1",
-                )
-                self.node_info = NodeInfo.from_node_def_and_config(
-                    self.node_definition, self.config
-                )
-                self.action_handlers = {}
-                self.action_history = {}
-                self.node_state = {}
-                self.logger = self.event_client = EventClient()
-                self.resource_client = ResourceClient(event_client=self.event_client)
-                self.data_client = DataClient()
-                self.node_status = NodeStatus(ready=True)
-
-        node = DummyNode()
-
         # Simulate a function signature with Union[str, int] (no LocationArgument)
         def test_func(target: Union[str, int] = "default"):
             pass
@@ -1083,7 +1013,9 @@ class TestLocationArgumentDetection:
         signature = inspect.signature(test_func)
         type_hints = get_type_hints(test_func, include_extras=True)
 
-        node._parse_action_arg(action_def, signature, "target", type_hints["target"])
+        dummy_node._parse_action_arg(
+            action_def, signature, "target", type_hints["target"]
+        )
 
         # Should NOT be detected as a location argument because Union doesn't contain LocationArgument
         assert "target" not in action_def.locations, (

--- a/src/madsci_resource_manager/pyproject.toml
+++ b/src/madsci_resource_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.resource_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Resource Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_squid/pyproject.toml
+++ b/src/madsci_squid/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.squid"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Control Server and Scheduler, aka Squid."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/src/madsci_workcell_manager/pyproject.toml
+++ b/src/madsci_workcell_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "madsci.workcell_manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "The Modular Autonomous Discovery for Science (MADSci) Workcell Manager."
 authors = [
     {name = "Tobias Ginsburg", email = "tginsburg@anl.gov"},

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squid_dashboard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_OPTIONS='--no-warnings' vite",


### PR DESCRIPTION
## PR Info

- Closes #159
- `LocationArgument`s in Union type hints are correctly marked as location arguments in action info

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
