### PR TITLE
Fix PR #180 review issues: decorator stacking, lazy loading, and docs…

### DIFF
--- a/src/madsci_common/madsci/common/context.py
+++ b/src/madsci_common/madsci/common/context.py
@@ -9,26 +9,44 @@ from madsci.common.types.context_types import MadsciContext
 
 
 class GlobalMadsciContext:
-    """A global MadsciContext object that can be accessed and modified throughout the application. This is intended to be used as a singleton that can be accessed from anywhere in the codebase, but should not be modified directly. Instead, use the madsci_context context manager to temporarily override values in the context."""
+    """
+    A global MadsciContext object for the application.
 
-    _context = MadsciContext()
+    This singleton can be accessed from anywhere in the codebase, but should
+    not be modified directly. Instead, use the madsci_context context manager
+    to temporarily override values in the context.
+    """
 
-    @property
+    _context: MadsciContext | None = None
+
     @classmethod
-    def context(cls) -> MadsciContext:
-        """Returns the current MadsciContext object."""
+    def get_context(cls) -> MadsciContext:
+        """
+        Get the global context, creating it lazily if needed.
+
+        Returns:
+            The global MadsciContext instance.
+        """
+        if cls._context is None:
+            cls._context = MadsciContext()
         return cls._context
 
-    @context.setter
     @classmethod
-    def context(cls, value: MadsciContext) -> None:
-        """Sets the current MadsciContext object."""
-        cls._context = value
+    def set_context(cls, context: MadsciContext) -> None:
+        """
+        Set the global context.
+
+        Args:
+            context: The MadsciContext instance to set as global.
+        """
+        cls._context = context
 
 
-_current_madsci_context = contextvars.ContextVar(
-    "current_madsci_context",
-    default=GlobalMadsciContext._context,
+_current_madsci_context: contextvars.ContextVar[MadsciContext | None] = (
+    contextvars.ContextVar(
+        "current_madsci_context",
+        default=None,
+    )
 )
 
 
@@ -36,19 +54,25 @@ _current_madsci_context = contextvars.ContextVar(
 def madsci_context(**overrides: dict[str, Any]) -> Generator[None, MadsciContext, None]:
     """Updates the current MadsciContext (as returned by get_current_madsci_context) with the provided overrides."""
     prev_context = _current_madsci_context.get()
+    if prev_context is None:
+        prev_context = GlobalMadsciContext.get_context()
     context = prev_context.model_copy()
     for k, v in overrides.items():
         setattr(context, k, v)
     token = _current_madsci_context.set(context)
     try:
-        yield _current_madsci_context.get()
+        yield _current_madsci_context.get()  # type: ignore[misc]
     finally:
         _current_madsci_context.reset(token)
 
 
 def get_current_madsci_context() -> MadsciContext:
     """Returns the current MadsciContext object."""
-    return _current_madsci_context.get()
+    context = _current_madsci_context.get()
+    if context is None:
+        context = GlobalMadsciContext.get_context()
+        _current_madsci_context.set(context)
+    return context
 
 
 def set_current_madsci_context(context: MadsciContext) -> None:


### PR DESCRIPTION
1. Fixed invalid @property/@classmethod decorator stacking (Comments 1 & 2)
   - Removed incompatible property/classmethod combinations
   - Replaced with proper @classmethod get_context() and set_context() methods
   - Maintains clean API while fixing Python decorator compatibility issues

2. Implemented true lazy loading to prevent --help arg capture
   - Changed _context from MadsciContext() to None as initial value
   - Context is now only created on first access via get_context()
   - This solves the original issue where module imports would capture CLI args

3. Fixed docstring formatting per PEP 257 (Comment 3)
   - Multi-line docstring with summary line
   - Blank line separator
   - Detailed description following PEP 257 standards

4. Updated all tests to use new classmethod API
   - All tests now call GlobalMadsciContext.get_context()
   - All tests now call GlobalMadsciContext.set_context()
   - Reduces verbose copy-modify-reassign patterns
   - All 7 tests pass successfully