### PR TITLE
fix method name in snippets in example_lab/README

### DIFF
--- a/example_lab/README.md
+++ b/example_lab/README.md
@@ -152,7 +152,7 @@ The example lab includes several pre-configured workflows demonstrating differen
 python -c "
 from madsci.client.workcell_client import WorkcellClient
 client = WorkcellClient()
-result = client.execute_workflow('workflows/simple_transfer.workflow.yaml')
+result = client.start_workflow('workflows/simple_transfer.workflow.yaml')
 print(f'Workflow result: {result}')
 "
 ```
@@ -163,7 +163,7 @@ print(f'Workflow result: {result}')
 python -c "
 from madsci.client.workcell_client import WorkcellClient
 client = WorkcellClient()
-result = client.execute_workflow('workflows/multistep_transfer.workflow.yaml')
+result = client.start_workflow('workflows/multistep_transfer.workflow.yaml')
 print(f'Workflow result: {result}')
 "
 ```
@@ -174,7 +174,7 @@ print(f'Workflow result: {result}')
 python -c "
 from madsci.client.workcell_client import WorkcellClient
 client = WorkcellClient()
-result = client.execute_workflow('workflows/minimal_test.workflow.yaml')
+result = client.start_workflow('workflows/minimal_test.workflow.yaml')
 print(f'Workflow result: {result}')
 "
 ```


### PR DESCRIPTION
## PR Info

This is a part of JOSS paper review https://github.com/openjournals/joss-reviews/issues/9416
Fix missing method name in snippets, which probably caused by a method name change in the past.

## Developer Checklists

I have:

- [ ] Run Pre-commit and Unit Tests, and ensured that they pass
- [ ] Created or updated documentation relevant to your change
- [ ] Created or updated unit tests relevant to your change
