### PR TITLE
Bundle agent skills into generated templates

### DIFF
--- a/.agents/skills/better-mousetraps/SKILL.md
+++ b/.agents/skills/better-mousetraps/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: better-mousetraps
+description: Evaluate build-vs-import decisions before writing new functionality. Use when (1) about to implement non-trivial functionality that likely exists as a library, (2) the user's request could be solved by an existing tool or package, (3) you catch yourself writing utility code (parsing, validation, HTTP, crypto, dates, etc.) that smells like a solved problem, or (4) planning a feature and need to weigh develop-in-house vs. adopt a dependency.
+---
+
+# Better Mousetraps: Build vs. Import
+
+Before writing non-trivial functionality from scratch, **stop and research whether a well-maintained solution already exists**. This applies whether the impulse to build comes from you or from the user's request.
+
+> "Most advice for technical leaders over-emphasizes the short-term risks of innovating too much, and under-emphasizes the long-term risks of innovating too little." — Marc Brooker
+
+The inverse is equally true for implementation work: most developers (and coding agents) over-emphasize the appeal of a custom solution and under-emphasize the value of a battle-tested dependency.
+
+## When This Skill Triggers
+
+Activate this decision framework whenever you're about to:
+
+- Write a utility function for a well-known problem domain (dates, parsing, validation, retries, HTTP, crypto, serialization, CLI argument parsing, etc.)
+- Implement an algorithm or data structure that has known optimized implementations
+- Build an integration layer with an external service or protocol
+- Create infrastructure code (logging, config, caching, task queues, etc.)
+- Solve a problem where you suspect libraries exist but aren't sure which
+
+## Step 1: Research First
+
+**Before writing any code**, spend time investigating existing options. This is not optional—it's the most valuable step.
+
+### How to Research
+
+1. **Web search** for `"python <problem domain> library"`, `"best <X> library 2025"`, `"<framework> <problem> package"`, etc.
+2. **Check PyPI / npm / crates.io** (whatever applies) for packages in the domain
+3. **Look at what the project already depends on**—many libraries have sub-features that solve adjacent problems (e.g., `pydantic` already handles validation, `httpx` already does retries with the right config)
+4. **Check the project's existing codebase**—maybe this is already solved elsewhere in the repo
+5. **Read "awesome" lists** and community recommendations for the domain
+
+### What to Look For in a Dependency
+
+| Signal | Good | Concerning |
+|--------|------|------------|
+| Maintenance | Regular commits, responsive issues | Abandoned, no releases in 2+ years |
+| Adoption | Widely used, many dependents | Few downloads, no community |
+| Scope | Focused, does one thing well | Kitchen-sink, pulls in heavy transitive deps |
+| License | Compatible with project (MIT, Apache, BSD) | Copyleft or unclear licensing |
+| Quality | Good docs, typed, tested | No docs, no types, no tests |
+| Fit | API matches your use case naturally | Requires heavy wrapping or workarounds |
+
+## Step 2: Evaluate the Tradeoffs
+
+Use these questions (adapted from [Brooker's framework](https://brooker.co.za/blog/2024/03/04/mousetrap.html)) to make a deliberate decision:
+
+### Questions That Favor Importing
+
+- **Is this a solved problem?** If the problem is well-understood with known best practices, prefer a library that encodes that knowledge.
+- **Is correctness critical?** Crypto, date math, Unicode handling, compression—these have subtle edge cases that mature libraries handle and hand-rolled code won't.
+- **Will you actually maintain this?** Custom code requires ongoing ownership. A dependency externalizes that burden.
+- **Are you solving the same problem as everyone else?** If your problem isn't unique, your solution shouldn't be either.
+
+### Questions That Favor Building
+
+- **Is your problem genuinely different?** Not "slightly different"—meaningfully different in ways that existing solutions can't accommodate.
+- **Is the dependency heavier than the problem?** If you need one function from a 50MB package, maybe write the function.
+- **Do you need deep control?** If you'll need to modify internals frequently, owning the code may be simpler.
+- **Is the ecosystem immature or unstable?** If available libraries are abandoned, poorly maintained, or have breaking changes every release, building may be more stable.
+- **Is this core differentiating logic?** If this is the thing that makes your project uniquely valuable, owning it makes sense.
+
+### The Scale Question
+
+Different scales require different solutions. A quick script might inline a 5-line parser; a production service should use a hardened library. Match the solution to the context.
+
+## Step 3: Present the Options
+
+When you've identified viable existing solutions, **present them to the user** before building from scratch. Structure your recommendation like this:
+
+```
+I found existing libraries that handle <problem>:
+
+1. **<library-a>** — <one-line description>. <fit assessment>.
+2. **<library-b>** — <one-line description>. <fit assessment>.
+3. **Build from scratch** — <what that would involve and why it might be justified>.
+
+I'd recommend <option> because <reasoning>. Want me to proceed with that?
+```
+
+Always include the "build from scratch" option with an honest assessment—sometimes it really is the right choice.
+
+## Step 4: Integrate Thoughtfully
+
+If adopting a dependency:
+
+- **Wrap it at the boundary** if the API might change or you might swap implementations later
+- **Pin versions** appropriately (exact for applications, compatible ranges for libraries)
+- **Check for conflicts** with existing dependencies
+- **Add it to the right dependency group** (dev, optional, core)
+- **Don't over-abstract**—a thin wrapper is fine, a full adapter layer is usually unnecessary
+
+If building from scratch:
+
+- **Document why** you didn't use an existing solution (a brief comment is sufficient)
+- **Keep the scope minimal**—solve your actual problem, not the general case
+- **Consider extracting later** if the solution proves generally useful
+
+## Anti-Patterns to Avoid
+
+1. **"Not Invented Here" syndrome**: Rejecting libraries because custom code feels more satisfying or controllable, without evaluating the actual tradeoffs.
+
+2. **Cargo-culting the user's request**: If the user says "write a function that does X", don't blindly comply if X is a well-solved problem. Suggest the library, explain why, and let them decide.
+
+3. **Premature generalization**: Building a general-purpose solution when a library already provides one. Your custom version will be less tested, less documented, and less maintained.
+
+4. **Dependency phobia**: Refusing all dependencies out of principle. Dependencies have costs, but so does hand-rolled code—and hand-rolled code has the additional cost of being untested by the broader community.
+
+5. **Shallow research**: Checking one search result and concluding "nothing exists." Spend real time looking. Try different search terms. Check what similar projects use.
+
+## Quick Reference: Common "Already Solved" Domains
+
+These domains almost always have mature, well-tested libraries. Default to importing unless you have a specific reason not to:
+
+| Domain | Think twice before hand-rolling |
+|--------|-------------------------------|
+| Date/time manipulation | Timezone bugs are legendary |
+| HTTP clients/servers | Connection pooling, retries, timeouts |
+| JSON/YAML/TOML parsing | Edge cases in specs are subtle |
+| Argument/CLI parsing | Flag handling, help generation |
+| Logging/structured logging | Output formatting, handlers, levels |
+| Validation | Schema validation, error messages |
+| Authentication/crypto | Security-critical, easy to get wrong |
+| Database ORMs/queries | SQL injection, connection management |
+| Retry/backoff logic | Jitter, exponential backoff, circuit breaking |
+| Rate limiting | Token bucket, sliding window algorithms |
+| Path/URL manipulation | Cross-platform edge cases |
+| Test fixtures/factories | Object generation, fake data |
+| CSV/Excel parsing | Encoding, malformed input handling |
+| Email parsing/sending | MIME, encoding, deliverability |
+| Markdown/HTML processing | XSS, spec compliance |

--- a/.agents/skills/madsci-cli
+++ b/.agents/skills/madsci-cli
@@ -1,0 +1,1 @@
+../../src/madsci_common/madsci/common/bundled_templates/_skills/madsci-cli

--- a/.agents/skills/madsci-experiments
+++ b/.agents/skills/madsci-experiments
@@ -1,0 +1,1 @@
+../../src/madsci_common/madsci/common/bundled_templates/_skills/madsci-experiments

--- a/.agents/skills/madsci-managers
+++ b/.agents/skills/madsci-managers
@@ -1,0 +1,1 @@
+../../src/madsci_common/madsci/common/bundled_templates/_skills/madsci-managers

--- a/.agents/skills/madsci-nodes
+++ b/.agents/skills/madsci-nodes
@@ -1,0 +1,1 @@
+../../src/madsci_common/madsci/common/bundled_templates/_skills/madsci-nodes

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: documentation-reviewer
+description: Use this agent when you need to review, evaluate, or improve documentation in README.md and AGENTS.md files for technical accuracy, clarity, and completeness. Examples: <example>Context: User has updated the README.md file with new installation instructions and wants to ensure quality. user: 'I just updated the README with new setup steps, can you review it?' assistant: 'I'll use the documentation-reviewer agent to evaluate the README for technical accuracy and completeness.' <commentary>Since the user wants documentation reviewed, use the documentation-reviewer agent to perform a thorough evaluation.</commentary></example> <example>Context: User is working on AGENTS.md and wants to ensure it follows best practices. user: 'Please check if our AGENTS.md file is clear and complete' assistant: 'Let me use the documentation-reviewer agent to analyze the AGENTS.md file for clarity, accuracy, and completeness.' <commentary>The user is requesting documentation review, so use the documentation-reviewer agent to evaluate the file.</commentary></example>
+model: inherit
+color: green
+---
+
+You are a rigorous technical writer and editor specializing in software documentation quality assurance. Your expertise lies in evaluating README.md and AGENTS.md files for technical accuracy, clarity, and completeness.
+
+When reviewing documentation, you will:
+
+1. **Technical Accuracy Assessment**: Verify that all technical information is correct, including:
+   - Command syntax and examples
+   - Code snippets and their functionality
+   - Installation and setup procedures
+   - API references and usage patterns
+   - Configuration options and their effects
+   - Cross-reference claims with actual codebase when possible
+
+2. **Clarity and Concision Evaluation**: Analyze writing quality by:
+   - Identifying unclear, ambiguous, or overly complex explanations
+   - Flagging redundant or verbose sections
+   - Ensuring logical flow and organization
+   - Checking that technical concepts are explained appropriately for the target audience
+   - Verifying consistent terminology usage throughout
+
+3. **Completeness Analysis**: Ensure comprehensive coverage by:
+   - Identifying missing critical information (setup steps, prerequisites, troubleshooting)
+   - Checking for gaps in workflow documentation
+   - Verifying that all major features and components are documented
+   - Ensuring examples cover common use cases
+   - Confirming that error handling and edge cases are addressed
+
+4. **Structure and Format Review**: Evaluate document organization by:
+   - Assessing heading hierarchy and navigation
+   - Checking markdown formatting consistency
+   - Verifying link functionality and accuracy
+   - Ensuring code blocks use appropriate syntax highlighting
+   - Confirming tables and lists are properly formatted
+
+5. **Project-Specific Compliance**: When working with MADSci documentation, ensure:
+   - Alignment with established coding standards and patterns
+   - Consistency with project architecture and terminology
+   - Proper documentation of microservices architecture
+   - Accurate reflection of PDM and just command usage
+   - Correct representation of ULID usage patterns
+
+Your output should be structured as:
+- **Summary**: Brief overview of overall documentation quality
+- **Technical Issues**: Specific inaccuracies or errors found
+- **Clarity Improvements**: Suggestions for clearer explanations
+- **Missing Content**: Gaps that should be addressed
+- **Formatting Issues**: Structural or markdown problems
+- **Recommendations**: Prioritized action items for improvement
+
+Be specific in your feedback, providing exact line references when possible, and offer concrete suggestions for improvement rather than just identifying problems.

--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -1,0 +1,55 @@
+---
+name: pr-code-reviewer
+description: Use this agent when reviewing pull requests or proposed code changes to ensure comprehensive evaluation of code quality, documentation updates, and test coverage. Examples: <example>Context: User has just finished implementing a new feature and wants to ensure their PR is ready for review. user: 'I've added a new authentication method to the user service. Can you review my changes?' assistant: 'I'll use the pr-code-reviewer agent to thoroughly evaluate your changes, including code quality, documentation updates, and test coverage.' <commentary>Since the user is requesting a comprehensive review of their code changes, use the pr-code-reviewer agent to evaluate the implementation, related documentation, and test coverage.</commentary></example> <example>Context: User has made changes to an existing API endpoint and wants to verify completeness. user: 'I modified the /api/users endpoint to include pagination. Here are my changes...' assistant: 'Let me use the pr-code-reviewer agent to review your pagination implementation and ensure all related components are properly updated.' <commentary>The user has made API changes that likely require documentation and test updates, making this a perfect case for the pr-code-reviewer agent.</commentary></example>
+model: inherit
+color: red
+---
+
+You are an expert Pull Request Code Reviewer with deep expertise in software engineering best practices, documentation standards, and comprehensive testing strategies. Your role is to conduct thorough, constructive reviews of proposed code changes to ensure high-quality, maintainable, and well-documented software.
+
+When reviewing code changes, you will:
+
+**Code Quality Assessment:**
+- Evaluate code structure, readability, and adherence to established patterns and conventions
+- Check for proper error handling, edge case coverage, and potential security vulnerabilities
+- Verify that the implementation follows SOLID principles and established architectural patterns
+- Assess performance implications and suggest optimizations where appropriate
+- Ensure proper use of language-specific idioms and best practices
+
+**Documentation Evaluation:**
+- Verify that all new public APIs, classes, and methods have appropriate documentation
+- Check that existing documentation has been updated to reflect any changes
+- Ensure README files, API documentation, and inline comments accurately represent the current functionality
+- Validate that configuration changes are documented with examples and explanations
+- Confirm that any breaking changes are clearly documented with migration guides
+
+**Test Coverage Analysis:**
+- Identify areas where new unit tests are required for added functionality
+- Verify that existing tests have been updated to reflect code changes
+- Check for adequate test coverage of edge cases, error conditions, and integration points
+- Ensure test quality, including proper assertions, meaningful test names, and appropriate test data
+- Validate that tests are maintainable and follow established testing patterns
+
+**Integration and Compatibility:**
+- Assess impact on existing functionality and backward compatibility
+- Check for proper dependency management and version compatibility
+- Verify that configuration changes are handled appropriately
+- Ensure database migrations or schema changes are properly implemented
+- Validate that the changes integrate well with the existing codebase architecture
+
+**Review Process:**
+1. Start with a high-level overview of the changes and their purpose
+2. Conduct detailed line-by-line code review, highlighting both strengths and areas for improvement
+3. Systematically check for missing or outdated documentation
+4. Analyze test coverage gaps and suggest specific test cases
+5. Provide actionable feedback with specific examples and suggestions
+6. Summarize findings with clear priorities (critical issues vs. suggestions)
+
+**Communication Style:**
+- Provide constructive, specific feedback with clear explanations
+- Suggest concrete improvements rather than just identifying problems
+- Acknowledge good practices and well-implemented solutions
+- Use a collaborative tone that encourages learning and improvement
+- Prioritize feedback by severity (blocking issues, important improvements, nice-to-haves)
+
+Your goal is to ensure that every code change maintains or improves the overall quality, maintainability, and reliability of the codebase while fostering a culture of continuous improvement and knowledge sharing.

--- a/.claude/agents/qa-test-validator.md
+++ b/.claude/agents/qa-test-validator.md
@@ -1,0 +1,52 @@
+---
+name: qa-test-validator
+description: Use this agent when you need to ensure all automated checks, tests, and quality gates are passing before code integration. Examples: <example>Context: User has just finished implementing a new feature and wants to validate everything is working correctly. user: 'I just added a new endpoint to the experiment manager. Can you make sure all the tests and checks are passing?' assistant: 'I'll use the qa-test-validator agent to run through all automated checks and ensure everything passes.' <commentary>Since the user wants comprehensive validation of tests and checks, use the qa-test-validator agent to systematically verify all quality gates.</commentary></example> <example>Context: User is preparing for a pull request and wants to ensure clean CI/CD pipeline execution. user: 'Before I submit this PR, I want to make sure I haven't broken anything' assistant: 'Let me use the qa-test-validator agent to run through all the automated checks and tests to ensure your changes are ready for review.' <commentary>The user needs comprehensive validation before code submission, so use the qa-test-validator agent to systematically check all quality gates.</commentary></example>
+model: inherit
+color: purple
+---
+
+You are an expert QA engineer specializing in automated testing and quality assurance for the MADSci scientific laboratory automation framework. Your mission is to ensure all automated checks, unit tests, and quality gates pass systematically before code integration.
+
+Your core responsibilities:
+
+1. **Systematic Test Execution**: Run tests in logical order using the project's established toolchain:
+   - Execute `just checks` for pre-commit hooks (ruff linting, formatting)
+   - Run `pytest` for comprehensive test suite execution
+   - Use `just test`, `just coverage`, or other just commands as appropriate
+   - Verify Docker builds with `just build` when relevant
+
+2. **Failure Analysis and Resolution**: When tests fail:
+   - Analyze failure output to identify root causes
+   - Distinguish between test failures, linting issues, formatting problems, and build errors
+   - Provide specific, actionable guidance for fixing each type of issue
+   - Re-run tests after fixes to confirm resolution
+
+3. **MADSci-Specific Quality Checks**: Ensure adherence to project standards:
+   - Verify ULID usage instead of UUIDs (use `new_ulid_str()` from `madsci.common.utils`)
+   - Check proper import organization and avoid circular dependencies
+   - Validate Pydantic v2 and SQLModel usage patterns
+   - Ensure proper use of `AnyUrl` for URL storage
+   - Verify manager service patterns and `AbstractManagerBase` inheritance
+
+4. **Comprehensive Coverage**: Systematically verify:
+   - Unit tests pass across all modified packages
+   - Integration tests execute successfully
+   - Code formatting meets ruff standards
+   - Linting rules are satisfied
+   - Type checking passes
+   - Docker builds complete without errors
+
+5. **Reporting and Documentation**: Provide clear status updates:
+   - Report which checks pass/fail with specific details
+   - Summarize remaining issues and next steps
+   - Confirm when all quality gates are satisfied
+   - Document any test environment setup requirements
+
+Your workflow approach:
+- Start with quick checks (linting, formatting) before running longer test suites
+- Use parallel execution when possible but respect test dependencies
+- Prioritize fixing blocking issues before proceeding to subsequent checks
+- Validate fixes incrementally rather than attempting to fix everything at once
+- Ensure the PDM virtual environment is activated when running Python commands
+
+You work methodically and persistently until all automated checks pass, providing clear guidance for resolving any issues encountered. You understand the MADSci architecture and can identify when failures relate to specific components (managers, nodes, clients) or cross-cutting concerns (configuration, types, utilities).

--- a/.claude/agents/senior-code-reviewer.md
+++ b/.claude/agents/senior-code-reviewer.md
@@ -1,0 +1,65 @@
+---
+name: senior-code-reviewer
+description: "Use this agent when you need comprehensive code review from a senior fullstack developer perspective, including analysis of code quality, architecture decisions, security vulnerabilities, performance implications, and adherence to best practices. Examples: <example>Context: User has just implemented a new authentication system with JWT tokens and wants a thorough review. user: 'I just finished implementing JWT authentication for our API. Here's the code...' assistant: 'Let me use the senior-code-reviewer agent to provide a comprehensive review of your authentication implementation.' <commentary>Since the user is requesting code review of a significant feature implementation, use the senior-code-reviewer agent to analyze security, architecture, and best practices.</commentary></example> <example>Context: User has completed a database migration script and wants it reviewed before deployment. user: 'Can you review this database migration script before I run it in production?' assistant: 'I'll use the senior-code-reviewer agent to thoroughly examine your migration script for potential issues and best practices.' <commentary>Database migrations are critical and require senior-level review for safety and correctness.</commentary></example>"
+model: inherit
+color: blue
+---
+
+You are a Senior Fullstack Code Reviewer, an expert software architect with 15+ years of experience across frontend, backend, database, and DevOps domains. You possess deep knowledge of multiple programming languages, frameworks, design patterns, and industry best practices.
+
+**Core Responsibilities:**
+- Conduct thorough code reviews with senior-level expertise
+- Analyze code for security vulnerabilities, performance bottlenecks, and maintainability issues
+- Evaluate architectural decisions and suggest improvements
+- Ensure adherence to coding standards and best practices
+- Identify potential bugs, edge cases, and error handling gaps
+- Assess test coverage and quality
+- Review database queries, API designs, and system integrations
+
+**Review Process:**
+1. **Context Analysis**: First, understand the full codebase context by examining related files, dependencies, and overall architecture
+2. **Comprehensive Review**: Analyze the code across multiple dimensions:
+   - Functionality and correctness
+   - Security vulnerabilities (OWASP Top 10, input validation, authentication/authorization)
+   - Performance implications (time/space complexity, database queries, caching)
+   - Code quality (readability, maintainability, DRY principles)
+   - Architecture and design patterns
+   - Error handling and edge cases
+   - Testing adequacy
+3. **Documentation Creation**: When beneficial for complex codebases, create claude_docs/ folders with markdown files containing:
+   - Architecture overviews
+   - API documentation
+   - Database schema explanations
+   - Security considerations
+   - Performance characteristics
+
+**Review Standards:**
+- Apply industry best practices for the specific technology stack
+- Consider scalability, maintainability, and team collaboration
+- Prioritize security and performance implications
+- Suggest specific, actionable improvements with code examples when helpful
+- Identify both critical issues and opportunities for enhancement
+- Consider the broader system impact of changes
+
+**Output Format:**
+- Start with an executive summary of overall code quality
+- Organize findings by severity: Critical, High, Medium, Low
+- Provide specific line references and explanations
+- Include positive feedback for well-implemented aspects
+- End with prioritized recommendations for improvement
+
+**Documentation Creation Guidelines:**
+Only create claude_docs/ folders when:
+- The codebase is complex enough to benefit from structured documentation
+- Multiple interconnected systems need explanation
+- Architecture decisions require detailed justification
+- API contracts need formal documentation
+
+When creating documentation, structure it as:
+- `/claude_docs/architecture.md` - System overview and design decisions
+- `/claude_docs/api.md` - API endpoints and contracts
+- `/claude_docs/database.md` - Schema and query patterns
+- `/claude_docs/security.md` - Security considerations and implementations
+- `/claude_docs/performance.md` - Performance characteristics and optimizations
+
+You approach every review with the mindset of a senior developer who values code quality, system reliability, and team productivity. Your feedback is constructive, specific, and actionable.

--- a/.claude/agents/tdd-engineer.md
+++ b/.claude/agents/tdd-engineer.md
@@ -1,0 +1,51 @@
+---
+name: tdd-engineer
+description: Use this agent when you need to implement new features, fix bugs, or accomplish software development tasks using test-driven development methodology. Examples: <example>Context: User wants to add a new validation function to their codebase. user: 'I need to add a function that validates email addresses according to RFC 5322 standards' assistant: 'I'll use the tdd-engineer agent to implement this using test-driven development methodology' <commentary>Since the user needs a new feature implemented, use the tdd-engineer agent to follow the red-green-refactor cycle for proper TDD implementation.</commentary></example> <example>Context: User has a failing test and needs to fix the underlying bug. user: 'My test_user_authentication is failing because the password hashing isn't working correctly' assistant: 'Let me use the tdd-engineer agent to fix this bug using TDD principles' <commentary>Since there's a bug to fix with an existing test, use the tdd-engineer agent to follow TDD methodology for the bug fix.</commentary></example>
+model: inherit
+color: cyan
+---
+
+You are an expert software engineer who specializes in Test-Driven Development (TDD) using the red-green-refactor methodology. You have deep expertise in writing clean, maintainable code through disciplined TDD practices and understand how to break down complex requirements into testable units.
+
+Your approach to every software development task follows the strict TDD cycle:
+
+**RED Phase**: Write a failing test first
+- Analyze the requirement and identify the smallest testable behavior
+- Write a minimal test that captures the expected behavior
+- Ensure the test fails for the right reason (not due to syntax errors)
+- Focus on the interface and expected outcomes before implementation
+
+**GREEN Phase**: Write the minimal code to make the test pass
+- Implement only enough code to satisfy the failing test
+- Resist the urge to over-engineer or add unnecessary features
+- Prioritize making the test pass over code elegance at this stage
+- Use the simplest solution that works, even if it seems naive
+
+**REFACTOR Phase**: Improve the code while keeping tests green
+- Eliminate duplication and improve code structure
+- Apply design patterns and best practices where appropriate
+- Ensure all tests continue to pass throughout refactoring
+- Improve readability, maintainability, and performance
+
+When working on tasks, you will:
+
+1. **Analyze Requirements**: Break down the task into small, testable behaviors and identify edge cases
+2. **Plan Test Cases**: Outline the sequence of tests needed, starting with the simplest happy path
+3. **Execute TDD Cycles**: Methodically work through red-green-refactor cycles for each behavior
+4. **Maintain Test Quality**: Write clear, focused tests with descriptive names and good assertions
+5. **Ensure Coverage**: Verify that your tests cover both expected behaviors and edge cases
+6. **Document Decisions**: Explain your testing strategy and any trade-offs made during implementation
+
+For bug fixes:
+- First write a test that reproduces the bug (red)
+- Fix the minimal code to make the test pass (green)
+- Refactor if needed while keeping all tests green
+
+For new features:
+- Start with the simplest use case and build incrementally
+- Each TDD cycle should add one small piece of functionality
+- Continuously refactor to maintain clean architecture
+
+You always consider the existing codebase context, follow established patterns and coding standards, and ensure your tests integrate well with existing test suites. When working with MADSci codebase, you follow the project's conventions including using ULID for ID generation, proper type annotations, and pytest for testing.
+
+Your code is always production-ready, well-tested, and follows software engineering best practices. You proactively identify potential issues and address them through comprehensive testing.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -321,8 +321,8 @@ coverage.xml
 src/madsci_resource_manager/madsci/resource_manager/alembic/versions/*.py
 
 
-# Agentic coding
-.claude/
+# Agentic coding (track .claude/ project config but ignore user-local settings)
+.claude/settings.local.json
 agent_docs/
 
 # Scratch directory for local testing

--- a/docs/api/madsci/common/types/template_types.md
+++ b/docs/api/madsci/common/types/template_types.md
@@ -43,6 +43,9 @@ Classes
     `parameters_used: dict[str, typing.Any]`
     :
 
+    `skills_included: list[str]`
+    :
+
     `template_name: str`
     :
 
@@ -299,6 +302,9 @@ Classes
     :
 
     `schema_version: str`
+    :
+
+    `skills: list[str]`
     :
 
     `tags: list[str]`

--- a/docs/guides/agent_skills.md
+++ b/docs/guides/agent_skills.md
@@ -98,7 +98,7 @@ The skills included depend on the template category:
 |-------------------|----------------|
 | Module, Node, Interface, Comm | `madsci-nodes` |
 | Experiment | `madsci-experiments` |
-| Workflow, Workcell | `madsci-managers` |
+| Workflow, Workcell | `madsci-nodes`, `madsci-managers`, `madsci-cli` |
 | Lab | All 4 skills |
 
 The skill files are output to `.agents/skills/{skill-name}/SKILL.md` in the generated project directory. No additional configuration is needed.

--- a/docs/guides/agent_skills.md
+++ b/docs/guides/agent_skills.md
@@ -1,0 +1,124 @@
+# Agent Skills Reference
+
+MADSci includes four domain-specific **skills** for AI coding agents (Claude Code, etc.). These skills auto-load contextual knowledge about MADSci's architecture, patterns, and conventions when working on relevant code, reducing errors and improving code quality.
+
+## Available Skills
+
+| Skill | Trigger | What It Teaches |
+|-------|---------|-----------------|
+| `madsci-nodes` | Node module code | AbstractNode, RestNode, `@action` decorator, file parameters, lifecycle, testing |
+| `madsci-experiments` | Experiment code | 4 modalities (Script, Notebook, TUI, Node), lifecycle, `manage_experiment()` |
+| `madsci-managers` | Manager services | AbstractManagerBase, settings, DB handlers, clients, health checks |
+| `madsci-cli` | CLI commands | Click commands, lazy loading, templates, start/stop, output helpers, TUI |
+
+## How Skills Work
+
+Skills are defined in `.agents/skills/madsci-*/SKILL.md` (symlinked from `.claude/skills/`). Each contains:
+
+- **Frontmatter** with a `name` and `description` that tells the agent when to activate
+- **Reference content** covering architecture, key files, code patterns, testing approaches, and common pitfalls
+
+### Automatic Activation
+
+Skills are **model-invocable** — the agent automatically loads the relevant skill when it detects you're working on related code. For example, asking "add a new action to the plate reader node" will auto-load `madsci-nodes`.
+
+### Manual Activation
+
+You can explicitly invoke a skill in Claude Code with a slash command:
+
+```
+/madsci-nodes
+/madsci-experiments
+/madsci-managers
+/madsci-cli
+```
+
+This is useful when you want to preload context before asking a question.
+
+## Skill Summaries
+
+### madsci-nodes
+
+Covers the node module development workflow for wrapping laboratory instruments behind MADSci's standard API.
+
+**Key topics:**
+- `AbstractNode` → `RestNode` class hierarchy
+- `@action` decorator usage, parameter types (`Path` for files, `LocationArgument`, `Annotated`)
+- Return types: plain dict, `Path`, `ActionFiles`, `ActionDatapoints`, tuples
+- Node lifecycle: `startup_handler()` → status/state loops → `shutdown_handler()`
+- REST 3-phase action execution (create → upload → start → poll → result)
+- Resource/location template registration via `ClassVar` lists
+- Testing with `start_node(testing=True)` and `TestClient`
+
+### madsci-experiments
+
+Covers the four experiment modalities and experiment lifecycle management.
+
+**Key topics:**
+- Choosing a modality: Script (batch), Notebook (Jupyter), TUI (interactive), Node (REST)
+- `ExperimentDesign` (template) vs `Experiment` (runtime instance)
+- `manage_experiment()` context manager for safe lifecycle handling
+- Client access via `MadsciClientMixin` (7 lazy client properties)
+- Pause/cancel handling with `check_experiment_status()`
+- Modality-specific patterns (Notebook cell workflow, TUI thread-safe events)
+
+### madsci-managers
+
+Covers the 7 manager services and their implementation patterns.
+
+**Key topics:**
+- `AbstractManagerBase[SettingsT]` with `classy_fastapi.Routable`
+- Settings: `prefixed_alias_generator()`, env prefixes, secret marking, `model_dump_safe()`
+- 4 database handler ABCs with real + in-memory implementations
+- Manager-specific details (ports, DB types, key endpoints, unique features)
+- `EventClient` dual nature (logging + HTTP), `MadsciClientMixin` lazy init
+- Health check overrides, OpenTelemetry integration
+- Testing with in-memory handlers (no Docker required)
+
+### madsci-cli
+
+Covers the `madsci` command-line interface architecture and extension.
+
+**Key topics:**
+- Click-based CLI with `AliasedGroup` and lazy loading via `_LAZY_COMMANDS`
+- Step-by-step guide for adding new commands
+- 17 commands with aliases and key flags
+- Template system (26 templates, `template.yaml` manifests, Jinja2)
+- Start/stop lifecycle (Docker vs local mode, PID tracking, health polling)
+- Output helpers (`get_console()`, `success()`, `error()`, etc.)
+- Testing with Click's `CliRunner`
+
+## Skills in Generated Projects
+
+When you scaffold a new project using `madsci new` or `madsci init`, the relevant agent skills are automatically copied into the generated project's `.agents/skills/` directory. This means AI coding agents working on the generated project will have MADSci domain knowledge from day one, without any manual setup.
+
+The skills included depend on the template category:
+
+| Template Category | Skills Included |
+|-------------------|----------------|
+| Module, Node, Interface, Comm | `madsci-nodes` |
+| Experiment | `madsci-experiments` |
+| Workflow, Workcell | `madsci-managers` |
+| Lab | All 4 skills |
+
+The skill files are output to `.agents/skills/{skill-name}/SKILL.md` in the generated project directory. No additional configuration is needed.
+
+## Customizing Skills
+
+Skills live in `.agents/skills/` and are symlinked into `.claude/skills/`. To modify a skill, edit the `SKILL.md` file directly. The frontmatter controls when the skill activates:
+
+```yaml
+---
+name: madsci-nodes
+description: Working with MADSci node modules for laboratory instrument integration...
+---
+```
+
+The `description` field is what the agent uses to decide whether to auto-load the skill, so keep it specific and action-oriented.
+
+## Other Available Skills
+
+In addition to the MADSci-specific skills, the project includes two general coding quality skills:
+
+- **`galahad`** — Testing, types, lints, and coverage best practices
+- **`code-ratchets`** — Preventing proliferation of deprecated code patterns via pre-commit ratchets

--- a/docs/guides/template_catalog.md
+++ b/docs/guides/template_catalog.md
@@ -8,6 +8,17 @@ madsci new list --category module     # Filter by category
 madsci new list --tag device          # Filter by tag
 ```
 
+### Bundled Agent Skills
+
+All templates automatically include relevant **agent skills** in the generated project's `.agents/skills/` directory. These skills provide AI coding agents (Claude Code, etc.) with domain-specific knowledge about MADSci patterns and conventions. See [Agent Skills Reference](agent_skills.md) for details.
+
+| Category | Bundled Skills |
+|----------|---------------|
+| Module, Node, Interface, Comm | `madsci-nodes` |
+| Experiment | `madsci-experiments` |
+| Workflow, Workcell | `madsci-managers` |
+| Lab | `madsci-nodes`, `madsci-experiments`, `madsci-managers`, `madsci-cli` |
+
 ---
 
 ## Module Templates (6)

--- a/docs/guides/template_catalog.md
+++ b/docs/guides/template_catalog.md
@@ -16,7 +16,7 @@ All templates automatically include relevant **agent skills** in the generated p
 |----------|---------------|
 | Module, Node, Interface, Comm | `madsci-nodes` |
 | Experiment | `madsci-experiments` |
-| Workflow, Workcell | `madsci-managers` |
+| Workflow, Workcell | `madsci-nodes`, `madsci-managers`, `madsci-cli` |
 | Lab | `madsci-nodes`, `madsci-experiments`, `madsci-managers`, `madsci-cli` |
 
 ---

--- a/myst.yml
+++ b/myst.yml
@@ -62,6 +62,7 @@ project:
         - file: docs/guides/workflow_development.md
         - file: docs/guides/observability.md
         - file: docs/guides/troubleshooting.md
+        - file: docs/guides/agent_skills.md
 
     - title: Equipment Integrator Guide
       children:

--- a/src/madsci_client/madsci/client/cli/commands/init.py
+++ b/src/madsci_client/madsci/client/cli/commands/init.py
@@ -7,9 +7,13 @@ using the template engine.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from madsci.common.types.template_types import GeneratedProject
+    from rich.console import Console
 
 
 def _collect_parameters(
@@ -48,8 +52,8 @@ def _collect_parameters(
 
 
 def _display_results(
-    console: Any,
-    result: Any,
+    console: Console,
+    result: GeneratedProject,
     output_dir: Path,
     lab_name: str,
 ) -> None:

--- a/src/madsci_client/madsci/client/cli/commands/init.py
+++ b/src/madsci_client/madsci/client/cli/commands/init.py
@@ -28,7 +28,7 @@ import click
     help="Skip interactive prompts; use defaults.",
 )
 @click.pass_context
-def init(
+def init(  # noqa: PLR0915
     ctx: click.Context,
     directory: str | None,
     template_name: str,
@@ -117,6 +117,11 @@ def init(
 
     for path in result.files_created:
         console.print(f"  [green]\u2713[/green] Created {path}")
+
+    if result.skills_included:
+        console.print(
+            f"  [green]\u2713[/green] Included {len(result.skills_included)} agent skill(s)"
+        )
 
     # Initialize .madsci/ sentry directory
     from madsci.common.sentry import ensure_madsci_dir

--- a/src/madsci_client/madsci/client/cli/commands/init.py
+++ b/src/madsci_client/madsci/client/cli/commands/init.py
@@ -7,8 +7,84 @@ using the template engine.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import click
+
+
+def _collect_parameters(
+    lab_name: str | None,
+    lab_description: str | None,
+    no_interactive: bool,
+) -> tuple[str, str]:
+    """Collect lab name and description via prompts or defaults.
+
+    Args:
+        lab_name: Pre-supplied lab name, or None to prompt.
+        lab_description: Pre-supplied description, or None to prompt.
+        no_interactive: If True, skip prompts and use defaults.
+
+    Returns:
+        Tuple of (lab_name, lab_description).
+    """
+    from rich.prompt import Prompt
+
+    if not no_interactive:
+        if not lab_name:
+            lab_name = Prompt.ask(
+                "  Lab name (lowercase, underscores or hyphens)",
+                default="my_lab",
+            )
+        if not lab_description:
+            lab_description = Prompt.ask(
+                "  Lab description",
+                default="A MADSci self-driving laboratory",
+            )
+    else:
+        lab_name = lab_name or "my_lab"
+        lab_description = lab_description or "A MADSci self-driving laboratory"
+
+    return lab_name, lab_description
+
+
+def _display_results(
+    console: Any,
+    result: Any,
+    output_dir: Path,
+    lab_name: str,
+) -> None:
+    """Display rendered template results and next-steps guidance.
+
+    Args:
+        console: Rich console instance.
+        result: GeneratedProject from the template engine.
+        output_dir: Directory where the lab was created.
+        lab_name: Name of the lab.
+    """
+    from madsci.common.sentry import ensure_madsci_dir
+
+    for path in result.files_created:
+        console.print(f"  [green]\u2713[/green] Created {path}")
+
+    if result.skills_included:
+        console.print(
+            f"  [green]\u2713[/green] Included {len(result.skills_included)} agent skill(s)"
+        )
+
+    lab_dir = output_dir / lab_name
+    madsci_dir = ensure_madsci_dir(lab_dir)
+    console.print(
+        f"  [green]\u2713[/green] Initialized {madsci_dir.relative_to(output_dir)}/"
+    )
+
+    console.print()
+    console.print("[bold]Next steps:[/bold]")
+    console.print(f"  1. cd {lab_name}")
+    console.print("  2. madsci start")
+    console.print("  3. Open http://localhost:8000 in your browser")
+    console.print()
+    console.print("For more information, run:")
+    console.print("  madsci --help")
 
 
 @click.command()
@@ -28,7 +104,7 @@ import click
     help="Skip interactive prompts; use defaults.",
 )
 @click.pass_context
-def init(  # noqa: PLR0915
+def init(
     ctx: click.Context,
     directory: str | None,
     template_name: str,
@@ -51,7 +127,6 @@ def init(  # noqa: PLR0915
     from madsci.client.cli.utils.output import get_console
     from madsci.common.templates.registry import TemplateRegistry
     from rich.panel import Panel
-    from rich.prompt import Prompt
 
     console = get_console(ctx)
 
@@ -64,21 +139,9 @@ def init(  # noqa: PLR0915
     )
     console.print()
 
-    # Collect parameters
-    if not no_interactive:
-        if not lab_name:
-            lab_name = Prompt.ask(
-                "  Lab name (lowercase, underscores or hyphens)",
-                default="my_lab",
-            )
-        if not lab_description:
-            lab_description = Prompt.ask(
-                "  Lab description",
-                default="A MADSci self-driving laboratory",
-            )
-    else:
-        lab_name = lab_name or "my_lab"
-        lab_description = lab_description or "A MADSci self-driving laboratory"
+    lab_name, lab_description = _collect_parameters(
+        lab_name, lab_description, no_interactive
+    )
 
     # Determine output directory
     output_dir = Path(directory) if directory else Path.cwd()
@@ -115,28 +178,4 @@ def init(  # noqa: PLR0915
     except Exception as exc:
         raise click.ClickException(f"Failed to render template: {exc}") from exc
 
-    for path in result.files_created:
-        console.print(f"  [green]\u2713[/green] Created {path}")
-
-    if result.skills_included:
-        console.print(
-            f"  [green]\u2713[/green] Included {len(result.skills_included)} agent skill(s)"
-        )
-
-    # Initialize .madsci/ sentry directory
-    from madsci.common.sentry import ensure_madsci_dir
-
-    lab_dir = output_dir / lab_name
-    madsci_dir = ensure_madsci_dir(lab_dir)
-    console.print(
-        f"  [green]\u2713[/green] Initialized {madsci_dir.relative_to(output_dir)}/"
-    )
-
-    console.print()
-    console.print("[bold]Next steps:[/bold]")
-    console.print(f"  1. cd {lab_name}")
-    console.print("  2. madsci start")
-    console.print("  3. Open http://localhost:8000 in your browser")
-    console.print()
-    console.print("For more information, run:")
-    console.print("  madsci --help")
+    _display_results(console, result, output_dir, lab_name)

--- a/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-cli/SKILL.md
+++ b/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-cli/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: madsci-cli
+description: Working with the MADSci CLI (the `madsci` command). Use when adding, modifying, or debugging CLI commands, or when using the CLI to operate a MADSci lab.
+---
+
+# MADSci CLI
+
+The `madsci` CLI is built on Click with lazy command loading, Rich output formatting, and a Textual TUI. It provides 17 commands for managing MADSci labs.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/madsci_client/madsci/client/cli/__init__.py` | Root command, `AliasedGroup`, `_LAZY_COMMANDS` |
+| `src/madsci_client/madsci/client/cli/commands/` | 17 command modules |
+| `src/madsci_client/madsci/client/cli/utils/output.py` | Rich console output helpers |
+| `src/madsci_client/madsci/client/cli/tui/app.py` | Textual TUI application |
+| `src/madsci_client/madsci/client/cli/tui/styles/theme.tcss` | TUI CSS theme |
+| `src/madsci_common/madsci/common/bundled_templates/` | 26 template manifests + Jinja2 files |
+
+## Architecture
+
+```
+madsci (AliasedGroup)
+  ├── Global options: --lab-url, -v, -q, --no-color, --json, --version
+  ├── Context: MadsciContext (lazy), Console, verbosity flags
+  └── Commands (lazy-loaded via _LAZY_COMMANDS):
+      ├── version, doctor (doc), status (s), logs (l)
+      ├── tui (ui), registry, migrate, new (n)
+      ├── start, stop, init, validate (val)
+      ├── run, completion, backup
+      ├── commands (cmd), config (cfg)
+      └── [aliases resolve via AliasedGroup]
+```
+
+### Lazy Command Loading
+
+Commands are loaded on first use to minimize CLI startup time:
+
+```python
+# In cli/__init__.py
+_LAZY_COMMANDS = {
+    "version": ("madsci.client.cli.commands.version", "version"),
+    "doctor": ("madsci.client.cli.commands.doctor", "doctor"),
+    "status": ("madsci.client.cli.commands.status", "status"),
+    "logs": ("madsci.client.cli.commands.logs", "logs"),
+    "tui": ("madsci.client.cli.commands.tui", "tui"),
+    "registry": ("madsci.client.cli.commands.registry", "registry"),
+    "migrate": ("madsci.client.cli.commands.migrate", "migrate"),
+    "new": ("madsci.client.cli.commands.new", "new"),
+    "start": ("madsci.client.cli.commands.start", "start"),
+    "stop": ("madsci.client.cli.commands.stop", "stop"),
+    "init": ("madsci.client.cli.commands.init", "init"),
+    "validate": ("madsci.client.cli.commands.validate", "validate"),
+    "run": ("madsci.client.cli.commands.run", "run"),
+    "completion": ("madsci.client.cli.commands.completion", "completion"),
+    "backup": ("madsci.client.cli.commands.backup", "backup"),
+    "commands": ("madsci.client.cli.commands.commands", "commands"),
+    "config": ("madsci.client.cli.commands.config", "config"),
+}
+```
+
+### AliasedGroup
+
+```python
+class AliasedGroup(click.Group):
+    _aliases: ClassVar[dict[str, str]] = {
+        "n": "new",
+        "s": "status",
+        "l": "logs",
+        "doc": "doctor",
+        "val": "validate",
+        "ui": "tui",
+        "cmd": "commands",
+        "cfg": "config",
+    }
+```
+
+Resolves aliases first, then tries eager commands, then lazy-imports.
+
+## Adding a New Command
+
+### Step 1: Create the command module
+
+```python
+# src/madsci_client/madsci/client/cli/commands/my_command.py
+import click
+
+@click.command()
+@click.pass_context
+def my_command(ctx: click.Context):
+    """One-line description shown in --help."""
+    # Lazy imports for heavy dependencies
+    from madsci.client.cli.utils.output import get_console, success
+
+    console = get_console(ctx)
+    success(console, "Command executed successfully")
+```
+
+### Step 2: Register in `_LAZY_COMMANDS`
+
+```python
+# In cli/__init__.py, add to _LAZY_COMMANDS dict:
+_LAZY_COMMANDS = {
+    ...
+    "my_command": ("madsci.client.cli.commands.my_command", "my_command"),
+}
+```
+
+### Step 3: (Optional) Add alias
+
+```python
+# In AliasedGroup._aliases:
+_aliases = {
+    ...
+    "mc": "my_command",
+}
+```
+
+**Critical rules:**
+- **Lazy imports are mandatory** for heavy dependencies (clients, types, etc.) - import inside the function body, not at module top
+- Use `@click.pass_context` to access the CLI context (console, verbosity, etc.)
+- All informational output should support `--json` via `ctx.obj["json"]`
+
+## Command Reference
+
+### `version`
+Display installed MADSci package versions, Python info, platform.
+- `--json`, `--check-updates`
+
+### `doctor` (alias: `doc`)
+System diagnostics: Python version, virtualenv, Docker, port availability.
+- `--fix`, `--check [python|docker|ports|network]`, `--json`
+
+### `status` (alias: `s`)
+Show health of MADSci services (hits `/health` endpoints).
+- `[services]` args, `-w/--watch`, `--interval`, `--timeout`, `--json`
+
+### `logs` (alias: `l`)
+View/stream logs from Event Manager.
+- `-f/--follow`, `--tail N`, `--since 5m/1h/1d`, `--level`, `--grep`, `--json`
+
+### `tui` (alias: `ui`)
+Launch Textual terminal UI with 5 screens (dashboard, status, logs, nodes, workflows).
+- `--screen [dashboard|status|logs|nodes|workflows]`
+- Keybindings: `d/s/l/n/w` (screens), `r` (refresh), `q` (quit), `?` (help), `Ctrl+P` (command palette)
+
+### `registry`
+Manage ID Registry (ULID mappings for component names).
+- Subcommands: `list [--type] [--include-stale]`, `resolve <name>`, `clean`
+
+### `migrate`
+Upgrade from deprecated definition files to Settings + ID Registry.
+- Subcommands: `scan [dir]`, `convert [--all]`, `status`, `finalize`
+
+### `new` (alias: `n`)
+Create new components from templates. Interactive parameter prompts.
+- Subcommands: `lab`, `module`, `node`, `interface`, `experiment`, `workflow`
+- `--tui` launches Textual template browser
+
+### `start`
+Start MADSci services.
+- `-d/--detach`, `--build`, `--services`, `--mode [docker|local]`, `--wait/--no-wait`, `--settings-dir`
+- Subcommands: `manager <name> [-d]`, `node <path> [-d]`
+- Docker mode: finds compose file, runs `docker compose up`
+- Local mode: all 7 managers in-process with in-memory backends (no Docker)
+
+### `stop`
+Stop MADSci services.
+- `--remove`, `--volumes` (requires confirmation), `--config`
+- Subcommands: `manager <name>`, `node <name>`
+
+### `init`
+Initialize new MADSci lab (scaffolds `.madsci/`, settings, templates).
+- `[directory]`, `--template [minimal]`, `--name`, `--description`, `--no-interactive`
+
+### `validate` (alias: `val`)
+Validate YAML configuration files (workflow, node, manager definitions).
+- `[paths]`, `--json`
+
+### `run`
+Execute workflows or experiments.
+- Subcommands: `workflow <path> [--workcell URL] [--parameters JSON] [--no-wait]`, `experiment <path>`
+
+### `completion`
+Generate shell completion scripts.
+- `<shell>` arg: `bash`, `zsh`, `fish`
+
+### `backup`
+Database backup management (re-exports from `madsci.common.backup_tools.cli`).
+- Subcommands: `create --db-url`, `restore --backup --db-url`, `validate --backup --db-url`
+- Auto-detects PostgreSQL vs MongoDB/FerretDB
+
+### `commands` (alias: `cmd`)
+Launch Trogon interactive command palette (TUI forms for all commands).
+
+### `config` (alias: `cfg`)
+Configuration management with secret redaction.
+- Subcommands: `export [manager_type] [--all] [-o path] [--format yaml|json] [--include-secrets]`, `create manager <type>`
+
+## Output Helpers
+
+```python
+from madsci.client.cli.utils.output import (
+    get_console,      # Get Rich Console from click context
+    output_result,    # Handles json/yaml/text output
+    success,          # Green checkmark message
+    error,            # Red X message (with optional details)
+    warning,          # Yellow warning message
+    info,             # Blue info message
+    print_panel,      # Rich Panel with border
+    format_url,       # Rich link format
+)
+
+# Usage pattern:
+console = get_console(ctx)
+success(console, "Operation completed")
+error(console, "Failed to connect", details="Connection refused on port 8001")
+
+# JSON-aware output:
+if ctx.obj.get("json"):
+    output_result(console, data, format="json")
+else:
+    output_result(console, data, format="text", title="Results")
+```
+
+## Template System
+
+Templates live in `src/madsci_common/madsci/common/bundled_templates/`. Each has a `template.yaml` manifest:
+
+```yaml
+name: "Module Name"
+version: "1.0.0"
+description: "What this template creates"
+category: "lab|module|node|interface|experiment|workflow"
+tags: ["device", "robot"]
+
+parameters:
+  - name: module_name
+    type: string
+    description: "Name of the module"
+    required: true
+    pattern: "^[a-z][a-z0-9_]*$"
+  - name: port
+    type: integer
+    description: "Server port"
+    default: 2000
+    min: 1024
+    max: 65535
+  - name: include_tests
+    type: boolean
+    description: "Include test files"
+    default: true
+
+files:
+  - source: "template/{{module_name}}_node.py.j2"
+    destination: "{{module_name}}/{{module_name}}_node.py"
+  - source: "template/test_node.py.j2"
+    destination: "{{module_name}}/tests/test_node.py"
+    condition: "{{ include_tests }}"
+
+hooks:
+  post_generate:
+    - command: "ruff format {{module_name}}/"
+      continue_on_error: true
+```
+
+**Template categories (26 total):**
+- `lab/`: minimal lab scaffold
+- `module/`: device, compute modules (full packages with tests, Dockerfile)
+- `node/`: basic node, rest node
+- `interface/`: node interface
+- `experiment/`: script, notebook, tui, node modalities
+- `workflow/`: basic workflow
+
+**Jinja2 filters:** `pascal_case` (converts `my_module` -> `MyModule`)
+
+## Start/Stop Lifecycle
+
+### Docker Mode (default)
+```bash
+madsci start              # docker compose up (foreground)
+madsci start -d           # detached + health polling
+madsci start --build      # rebuild images first
+madsci start --services event resource  # specific services
+madsci stop               # docker compose down
+madsci stop --volumes     # remove volumes (data loss!)
+```
+
+### Local Mode (no Docker)
+```bash
+madsci start --mode=local     # All 7 managers in-process, in-memory backends
+madsci start --mode=local -d  # Background with PID tracking
+```
+
+### Individual Services
+```bash
+madsci start manager event -d     # Start Event Manager in background
+madsci start node ./my_node.py -d # Start node in background
+madsci stop manager event         # Stop background Event Manager
+madsci stop node my_node          # Stop background node
+```
+
+### PID Tracking
+- PIDs stored in `.madsci/pids/{name}.pid` (JSON: `{pid, exe, name}`)
+- Logs stored in `.madsci/logs/{name}_TIMESTAMP.log`
+- Process identity verified to prevent PID reuse
+- Stop sends SIGTERM, waits 5s for exit
+
+### Health Polling (`-d` with `--wait`)
+After detached start, polls `/health` on each service every 2s (timeout: 60s). Displays live Rich table with status.
+
+## TUI Application
+
+5 screens built with Textual:
+
+| Screen | Key | Description |
+|--------|-----|-------------|
+| Dashboard | `d` | Service overview, quick actions, recent events |
+| Status | `s` | Detailed health with infrastructure checks |
+| Logs | `l` | Log viewer with filtering and follow mode |
+| Nodes | `n` | Node registry with status and actions |
+| Workflows | `w` | Workflow history and details |
+
+- Auto-refresh every 5 seconds
+- CSS theming in `tui/styles/theme.tcss`
+- Trogon integration via `Ctrl+P`
+
+## Testing CLI Commands
+
+Use Click's `CliRunner`:
+
+```python
+from click.testing import CliRunner
+from madsci.client.cli import madsci
+
+def test_version_command():
+    runner = CliRunner()
+    result = runner.invoke(madsci, ["version"])
+    assert result.exit_code == 0
+    assert "madsci" in result.output
+
+def test_version_json():
+    runner = CliRunner()
+    result = runner.invoke(madsci, ["version", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert "packages" in data
+
+def test_command_alias():
+    runner = CliRunner()
+    result = runner.invoke(madsci, ["s"])  # alias for "status"
+    # Will fail to connect but should parse correctly
+    assert result.exit_code in (0, 1)
+```
+
+**Smoke test pattern:** Verify all 17 commands parse without import errors:
+```python
+@pytest.mark.parametrize("cmd", ["version", "doctor", "status", ...])
+def test_command_help(cmd):
+    runner = CliRunner()
+    result = runner.invoke(madsci, [cmd, "--help"])
+    assert result.exit_code == 0
+```
+
+## Common Pitfalls
+
+- **Lazy imports mandatory**: Heavy deps (clients, types, managers) must be imported inside function bodies, not at module top. Startup time is critical.
+- **`_LazyMadsciContext`**: The context object is lazy; it only initializes `MadsciContext` when attributes are first accessed. Don't force early initialization.
+- **yarn, not npm**: UI directory uses `yarn` for Node.js package management
+- **Compose file discovery**: `start` searches for `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml` in current and parent directories
+- **ULID not UUID**: Use `new_ulid_str()` for any IDs
+- **AnyUrl trailing slash**: All URLs stored via Pydantic AnyUrl get a trailing slash
+- **JSON output**: All informational commands should support `--json` output mode
+- **Click groups vs commands**: `start` and `stop` are Click groups with `manager`/`node` subcommands
+- **Trogon patch**: The `commands` command patches Trogon's `_apply_default_value` for Click `Sentinel.UNSET` compatibility

--- a/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-experiments/SKILL.md
+++ b/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-experiments/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: madsci-experiments
+description: Working with MADSci experiment modalities and the experiment lifecycle. Use when creating, modifying, or debugging experiments using ExperimentScript, ExperimentNotebook, ExperimentTUI, or ExperimentNode.
+---
+
+# MADSci Experiments
+
+MADSci provides four experiment modalities, all built on `ExperimentBase` which uses `MadsciClientMixin` (composition, not RestNode inheritance). Choose the right modality for your use case, then implement `run_experiment()`.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/madsci_experiment_application/madsci/experiment_application/experiment_base.py` | Base class, lifecycle, context manager |
+| `src/madsci_experiment_application/madsci/experiment_application/experiment_script.py` | Simple run-once modality |
+| `src/madsci_experiment_application/madsci/experiment_application/experiment_notebook.py` | Jupyter notebook modality |
+| `src/madsci_experiment_application/madsci/experiment_application/experiment_tui.py` | Terminal UI modality |
+| `src/madsci_experiment_application/madsci/experiment_application/experiment_node.py` | REST server modality |
+| `src/madsci_common/madsci/common/types/experiment_types.py` | ExperimentDesign, Experiment, ExperimentStatus |
+| `src/madsci_client/madsci/client/experiment_client.py` | Experiment Manager HTTP client |
+| `src/madsci_client/madsci/client/client_mixin.py` | MadsciClientMixin with 7 lazy client properties |
+| `src/madsci_common/madsci/common/bundled_templates/experiment/` | Templates for all 4 modalities |
+
+## Choosing a Modality
+
+| Modality | Best For | Entry Point | Interactive? |
+|----------|----------|-------------|-------------|
+| **ExperimentScript** | Batch processing, automated pipelines | `run()` or `main()` | No |
+| **ExperimentNotebook** | Exploratory analysis, Jupyter workflows | `start()` / `end()` | Yes (cell-by-cell) |
+| **ExperimentTUI** | Operator-attended experiments needing pause/cancel | `run_tui()` | Yes (terminal) |
+| **ExperimentNode** | Remote-controlled experiments via REST API | `start_server()` | Via HTTP |
+
+## Architecture
+
+```
+ExperimentBase (MadsciClientMixin)
+  ├── ExperimentScript     # run() -> manage_experiment() -> run_experiment()
+  ├── ExperimentNotebook   # start() / end() with Rich display
+  ├── ExperimentTUI        # Textual TUI with threading.Event pause/cancel
+  └── ExperimentNode       # Wraps RestNode internally, exposes run_experiment as action
+```
+
+**Key design choice:** ExperimentBase uses composition (MadsciClientMixin), not inheritance from RestNode. Only ExperimentNode creates a RestNode internally when it needs server capabilities.
+
+## ExperimentDesign vs Experiment
+
+- **ExperimentDesign**: Template/blueprint. Defines experiment_name, description, resource_conditions. Reusable across runs. Can be loaded from YAML.
+- **Experiment**: Runtime instance. Has experiment_id (ULID), status, timestamps, ownership. Created by `start_experiment_run()`.
+
+```python
+from madsci.common.types.experiment_types import ExperimentDesign
+
+design = ExperimentDesign(
+    experiment_name="Synthesis Optimization",
+    experiment_description="Optimize reaction conditions for compound X",
+)
+
+# Or load from YAML
+design = ExperimentDesign.from_yaml("experiment_design.yaml")
+```
+
+## ExperimentScript (Simplest Modality)
+
+```python
+from madsci.experiment_application.experiment_script import ExperimentScript
+from madsci.common.types.experiment_types import ExperimentDesign
+
+class SynthesisExperiment(ExperimentScript):
+    experiment_design = ExperimentDesign(
+        experiment_name="Synthesis Run",
+        experiment_description="Automated synthesis workflow",
+    )
+
+    def run_experiment(self, sample_id: str = "default", cycles: int = 3) -> dict:
+        """Core experiment logic. Called within manage_experiment() context."""
+        results = []
+        for i in range(cycles):
+            result = self.workcell_client.run_workflow(
+                "synthesis", parameters={"sample_id": sample_id, "cycle": i}
+            )
+            results.append(result)
+            self.logger.info("Cycle completed", cycle=i, result=result)
+
+        return {"sample_id": sample_id, "results": results}
+
+if __name__ == "__main__":
+    SynthesisExperiment.main(sample_id="ABC123", cycles=5)
+```
+
+**Entry points:**
+- `run(*args, **kwargs)`: Instance method. Merges config args with passed args.
+- `main(*args, **kwargs)`: Class method. Creates instance and calls `run()`.
+
+**Config class:** `ExperimentScriptConfig` adds `run_args` and `run_kwargs` fields for CLI/env configuration.
+
+## ExperimentNotebook (Jupyter)
+
+Designed for cell-by-cell interactive use in Jupyter notebooks.
+
+```python
+# Cell 1: Setup
+from my_experiment import MyNotebookExperiment
+exp = MyNotebookExperiment()
+
+# Cell 2: Start
+exp.start(run_name="Exploration Run 1")
+
+# Cell 3: Execute
+result = exp.run_workflow("characterize", parameters={"sample": "S1"})
+
+# Cell 4: Visualize
+exp.display(result, title="Characterization Results")
+
+# Cell 5: End
+exp.end()
+```
+
+**Or use as context manager:**
+```python
+with MyNotebookExperiment() as exp:
+    result = exp.run_workflow("synthesis")
+    exp.display(result, title="Results")
+```
+
+**Key methods:**
+- `start(run_name, run_description)`: Starts experiment, displays status. Returns `self`.
+- `end(status)`: Ends experiment, displays summary. Returns `self`.
+- `run_workflow(workflow_name, parameters, display_result)`: Convenience wrapper for `workcell_client.run_workflow()`.
+- `display(data, title)`: Rich-formatted display (falls back to plain print).
+
+**Config class:** `ExperimentNotebookConfig` adds `rich_output: bool = True` and `auto_display_results: bool = True`.
+
+## ExperimentTUI (Terminal UI)
+
+Interactive terminal interface with pause/cancel controls via Textual.
+
+```python
+from madsci.experiment_application.experiment_tui import ExperimentTUI
+from madsci.common.types.experiment_types import ExperimentDesign
+
+class OperatorExperiment(ExperimentTUI):
+    experiment_design = ExperimentDesign(
+        experiment_name="Operator-Assisted Synthesis",
+    )
+
+    def run_experiment(self) -> dict:
+        results = []
+        for step in range(10):
+            self.check_experiment_status()  # Handles pause/cancel locally
+            result = self.workcell_client.run_workflow("step", parameters={"n": step})
+            results.append(result)
+        return {"steps_completed": len(results)}
+
+if __name__ == "__main__":
+    OperatorExperiment().run_tui()
+```
+
+**Thread-safe controls:**
+- `request_pause()` / `request_resume()` / `request_cancel()`: Called from TUI thread
+- `check_experiment_status()`: Called in experiment thread. Uses `threading.Event` (no server round-trips). Raises `ExperimentCancelledError` if cancelled. Blocks while paused.
+
+**Config class:** `ExperimentTUIConfig` adds `refresh_interval: float = 1.0` and `show_logs: bool = True`.
+
+**Requires:** `pip install textual` (optional dependency).
+
+## ExperimentNode (REST Server)
+
+Exposes `run_experiment()` as a node action, controllable via the workcell manager.
+
+```python
+from madsci.experiment_application.experiment_node import ExperimentNode
+from madsci.common.types.experiment_types import ExperimentDesign
+
+class RemoteExperiment(ExperimentNode):
+    experiment_design = ExperimentDesign(
+        experiment_name="Remote Synthesis",
+    )
+
+    def run_experiment(self, sample_id: str, temperature: float = 25.0) -> dict:
+        return self.workcell_client.run_workflow(
+            "process", parameters={"sample_id": sample_id, "temp": temperature}
+        )
+
+if __name__ == "__main__":
+    RemoteExperiment().start_server()
+```
+
+**Internals:** Creates a `RestNode` instance internally. Wraps `run_experiment` as a non-blocking action inside `manage_experiment()` context.
+
+**Config class:** `ExperimentNodeConfig` adds `server_host: str = "0.0.0.0"`, `server_port: int = 6000`, `cors_enabled: bool = True`.
+
+## Lifecycle and Context Manager
+
+### `manage_experiment()` (Recommended)
+
+```python
+with self.manage_experiment(run_name="Run 1") as exp:
+    # Experiment started, logging context established
+    result = exp.workcell_client.run_workflow("my_workflow")
+    # On success: end_experiment(COMPLETED) called automatically
+    # On exception: handle_exception() called, then re-raised
+```
+
+The context manager:
+1. Calls `start_experiment_run()` -> registers with Experiment Manager
+2. Sets up hierarchical logging context (experiment_id, experiment_name, run_name, experiment_type)
+3. Yields `self`
+4. On success: `end_experiment(COMPLETED)`
+5. On exception: `handle_exception()` then re-raises
+
+### Manual lifecycle
+```python
+exp.start_experiment_run(run_name="Manual Run")
+try:
+    exp.run_experiment()
+    exp.end_experiment(status=ExperimentStatus.COMPLETED)
+except Exception as e:
+    exp.handle_exception(e)
+    raise
+```
+
+### Exception handling
+Override `handle_exception()` for custom behavior:
+```python
+def handle_exception(self, exception: Exception) -> None:
+    if isinstance(exception, RecoverableError):
+        self.logger.warning("Recoverable error, retrying", error=str(exception))
+        return  # Don't end experiment
+    super().handle_exception(exception)  # Logs error + ends with FAILED
+```
+
+## ExperimentStatus
+
+```python
+class ExperimentStatus(str, Enum):
+    IN_PROGRESS = "in_progress"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+```
+
+## Exception Types
+
+```python
+from madsci.common.exceptions import (
+    ExperimentCancelledError,    # Raised when experiment cancelled externally
+    ExperimentFailedError,       # Raised when experiment fails externally
+    ExperimentPauseTimeoutError, # Raised when pause exceeds max_pause_wait
+)
+```
+
+## Client Access (via MadsciClientMixin)
+
+All experiment modalities provide 7 lazy-initialized client properties:
+
+```python
+self.event_client       # EventClient - logging and events
+self.logger             # Alias for event_client
+self.resource_client    # ResourceClient - inventory
+self.data_client        # DataClient - data storage
+self.experiment_client  # ExperimentClient - experiment lifecycle
+self.workcell_client    # WorkcellClient - workflow execution
+self.location_client    # LocationClient - locations
+self.lab_client         # LabClient - lab coordination
+```
+
+Clients are created on first access. URLs resolved from config or lab context (service discovery).
+
+## Configuration
+
+All configs inherit from `ExperimentBaseConfig` (`MadsciBaseSettings`, env prefix `EXPERIMENT_`):
+
+```python
+# Common fields (ExperimentBaseConfig):
+lab_server_url: Optional[AnyUrl]         # Lab manager for service discovery
+event_server_url: Optional[AnyUrl]       # Override Event Manager URL
+experiment_server_url: Optional[AnyUrl]  # Override Experiment Manager URL
+workcell_server_url: Optional[AnyUrl]    # Override Workcell Manager URL
+data_server_url: Optional[AnyUrl]        # Override Data Manager URL
+resource_server_url: Optional[AnyUrl]    # Override Resource Manager URL
+location_server_url: Optional[AnyUrl]    # Override Location Manager URL
+max_pause_wait: Optional[float]          # Max seconds to wait while paused (None = forever)
+```
+
+Config files searched via walk-up: `settings.yaml`, `experiment.settings.yaml`, `.env`, `experiment.env`.
+
+## Creating Experiments from Templates
+
+```bash
+madsci new experiment
+# Choose modality: script, notebook, tui, node
+# Provide: experiment_name, description
+```
+
+Templates in `src/madsci_common/madsci/common/bundled_templates/experiment/`:
+- `script/` -> `{name}.py`
+- `notebook/` -> `{name}.ipynb`
+- `tui/` -> `{name}_tui.py`
+- `node/` -> `{name}_node.py`
+
+## Checking Experiment Status (Pause/Cancel)
+
+Call `check_experiment_status()` at natural checkpoints in long-running experiments:
+
+```python
+def run_experiment(self):
+    for batch in batches:
+        self.check_experiment_status()  # Blocks if paused, raises if cancelled
+        process(batch)
+```
+
+**ExperimentTUI behavior:** Uses local `threading.Event` (no network calls).
+**Other modalities:** Polls Experiment Manager with exponential backoff (5s -> 60s). Logs "Still waiting" every 5 minutes.
+
+## Common Pitfalls
+
+- **Override `run_experiment()`, not `run()`**: `run()` handles lifecycle; `run_experiment()` is your logic
+- **Use `manage_experiment()` context manager**: Ensures proper start/end and exception handling
+- **ULID not UUID**: Use `new_ulid_str()` for any IDs you generate
+- **Notebook start/end**: Must call `start()` before `run_workflow()` and `end()` when done
+- **TUI requires textual**: `pip install textual` or it raises ImportError
+- **ExperimentApplication is deprecated**: Use the 4 modalities above instead (removal in v0.8.0)
+- **Client URLs**: Set via config, env vars (`EXPERIMENT_EVENT_SERVER_URL`), or lab context (service discovery via `lab_server_url`)
+- **AnyUrl trailing slash**: Pydantic's `AnyUrl` always adds a trailing slash

--- a/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-managers/SKILL.md
+++ b/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-managers/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: madsci-managers
+description: Working with MADSci manager services (Event, Experiment, Resource, Data, Workcell, Location, Lab). Use when creating, modifying, debugging, or configuring manager servers.
+---
+
+# MADSci Manager Services
+
+MADSci has 7 manager services, all built on `AbstractManagerBase[SettingsT]` with FastAPI via `classy_fastapi.Routable`. Each follows the pattern: **Settings class** -> **Server class** -> **Client class**.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/madsci_common/madsci/common/manager_base.py` | `AbstractManagerBase` - common server lifecycle, health, CORS, OTEL |
+| `src/madsci_common/madsci/common/types/manager_types.py` | `ManagerSettings`, `ManagerHealth` base types |
+| `src/madsci_common/madsci/common/types/base_types.py` | `MadsciBaseSettings`, `prefixed_alias_generator()` |
+| `src/madsci_common/madsci/common/db_handlers/` | 4 handler ABCs + real + in-memory implementations |
+| `src/madsci_*/madsci/*/*_server.py` | Each manager's server implementation |
+| `src/madsci_client/madsci/client/` | All client implementations |
+| `src/madsci_client/madsci/client/client_mixin.py` | `MadsciClientMixin` for lazy client access |
+
+## The 7 Managers
+
+| Manager | Port | Database | Handler Params | Key Domain |
+|---------|------|----------|----------------|------------|
+| **Lab (Squid)** | 8000 | None | N/A | Dashboard, service discovery, health aggregation |
+| **Event** | 8001 | FerretDB | `document_handler` | Distributed event logging, retention, analytics |
+| **Experiment** | 8002 | FerretDB | `document_handler` | Experiment lifecycle (start/pause/cancel/end) |
+| **Resource** | 8003 | PostgreSQL | `postgres_handler` | Inventory, containers (Queue/Stack/Slot), templates |
+| **Data** | 8004 | FerretDB + S3 | `document_handler`, `object_storage_handler` | DataPoints (value/file), dual storage |
+| **Workcell** | 8005 | FerretDB + Valkey | `document_handler`, `cache_handler` | Workflow execution, scheduling, node coordination |
+| **Location** | 8006 | FerretDB + Valkey | `document_handler`, `cache_handler` | Location management, transfer planning, representations |
+
+## Manager Implementation Pattern
+
+### 1. Settings Class
+
+```python
+from madsci.common.types.manager_types import ManagerSettings
+from madsci.common.types.base_types import prefixed_alias_generator, prefixed_model_validator
+
+class MyManagerSettings(ManagerSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="MYMANAGER_",
+        alias_generator=prefixed_alias_generator("mymanager"),
+        populate_by_name=True,
+    )
+    _accept_prefixed_keys = prefixed_model_validator("mymanager")
+
+    server_url: AnyUrl = Field(default="http://localhost:8007/")
+    document_db_url: AnyUrl = Field(default="mongodb://localhost:27017/")
+    database_name: str = Field(default="madsci_mymanager")
+```
+
+**Key points:**
+- `env_prefix`: Environment variable prefix (e.g., `MYMANAGER_SERVER_URL`)
+- `prefixed_alias_generator`: Enables prefixed keys in YAML (e.g., `mymanager_server_url`)
+- `prefixed_model_validator`: Accepts prefixed keys during model initialization
+- Code uses unprefixed names (`server_url`), YAML/export uses prefixed (`mymanager_server_url`)
+- `model_dump(by_alias=True)` -> prefixed keys; `model_dump()` -> unprefixed
+
+### 2. Server Class
+
+```python
+from madsci.common.manager_base import AbstractManagerBase
+
+class MyManager(AbstractManagerBase[MyManagerSettings]):
+    SETTINGS_CLASS = MyManagerSettings
+
+    def initialize(self, **kwargs):
+        """Called during __init__ after base setup. Set up DB connections, etc."""
+        self._document_handler = kwargs.get("document_handler") or PyDocumentStorageHandler(
+            url=str(self.settings.document_db_url),
+            database_name=self.settings.database_name,
+        )
+
+    def get_health(self) -> MyManagerHealth:
+        """Override to add DB connectivity checks."""
+        try:
+            connected = self._document_handler.ping()
+            return MyManagerHealth(healthy=connected, db_connected=connected)
+        except Exception as e:
+            return MyManagerHealth(healthy=False, description=str(e))
+
+    @get("/items")
+    def list_items(self) -> list[Item]:
+        """Custom endpoint using classy_fastapi @get/@post decorators."""
+        ...
+
+    @post("/items")
+    def create_item(self, item: Item) -> Item:
+        ...
+```
+
+**AbstractManagerBase provides:**
+- `GET /health` -> calls `get_health()`
+- `GET /settings` -> exports settings with secret redaction
+- CORS middleware (configurable)
+- Rate limiting middleware
+- OpenTelemetry instrumentation (if enabled)
+- Ownership context middleware
+- Registry identity resolution (stable IDs across restarts)
+- `self.logger` (EventClient) for structured logging
+- `self.span(name, attributes)` context manager for OTEL tracing
+- `create_server()` and `run_server()` for lifecycle management
+
+### 3. Client Class
+
+```python
+from madsci.client.base_client import BaseClient
+
+class MyManagerClient:
+    def __init__(self, server_url: AnyUrl, config=None, event_client=None):
+        self.server_url = str(server_url)
+        self._session = None  # Lazy HTTP session
+
+    def list_items(self, timeout=None) -> list[Item]:
+        response = self._get("/items", timeout=timeout)
+        return [Item(**item) for item in response.json()]
+
+    def create_item(self, item: Item, timeout=None) -> Item:
+        response = self._post("/items", json=item.model_dump(), timeout=timeout)
+        return Item(**response.json())
+
+    def close(self):
+        """Release HTTP session resources."""
+        if self._session:
+            self._session.close()
+```
+
+**All clients have:**
+- Lazy HTTP session initialization
+- `close()` method for cleanup
+- Optional `EventClient` injection for logging
+- Configurable retry behavior
+
+## Settings and Configuration
+
+### Prefixed Alias System
+
+Each manager uses `prefixed_alias_generator()` for YAML-friendly configuration:
+
+```yaml
+# settings.yaml (shared across managers)
+event_server_url: http://localhost:8001/
+event_database_name: madsci_events
+resource_postgres_db_url: postgresql://localhost/resources
+workcell_cache_url: redis://localhost:6379/
+```
+
+```python
+# In code, use unprefixed names:
+self.settings.server_url       # "http://localhost:8001/"
+self.settings.database_name    # "madsci_events"
+```
+
+### Secret Marking and Redaction
+
+```python
+# Type-based:
+password: SecretStr
+
+# Metadata-based:
+api_key: str = Field(json_schema_extra={"secret": True})
+
+# Safe export (redacts secrets):
+settings.model_dump_safe()
+
+# Settings endpoint uses:
+get_settings_export(include_secrets=False)  # Default
+```
+
+### Environment Variable Precedence
+CLI args > init kwargs > env vars > .env > file secrets > JSON > TOML > YAML > field defaults
+
+## Database Handler Abstraction
+
+4 handler ABCs with real and in-memory implementations:
+
+### DocumentStorageHandler (FerretDB/MongoDB)
+
+```python
+from madsci.common.db_handlers.document_storage_handler import (
+    DocumentStorageHandler,       # ABC
+    PyDocumentStorageHandler,     # Real (pymongo)
+    InMemoryDocumentStorageHandler,  # Testing
+)
+
+# Production:
+handler = PyDocumentStorageHandler(url="mongodb://localhost:27017", database_name="madsci_events")
+collection = handler.get_collection("events")
+collection.insert_one({"event": "data"})
+
+# Testing:
+handler = InMemoryDocumentStorageHandler()
+```
+
+**Used by:** Event, Experiment, Data, Workcell, Location managers
+
+### CacheHandler (Valkey/Redis)
+
+```python
+from madsci.common.db_handlers.cache_handler import (
+    CacheHandler,          # ABC
+    PyCacheHandler,        # Real (redis + pottery)
+    InMemoryCacheHandler,  # Testing
+)
+
+# Production:
+handler = PyCacheHandler(url="redis://localhost:6379")
+state_dict = handler.create_dict("workcell_state")  # pottery RedisDict-like
+lock = handler.create_lock("operation_lock", auto_release_time=30)
+
+# Testing:
+handler = InMemoryCacheHandler()
+```
+
+**Used by:** Workcell, Location managers
+
+### PostgresHandler (PostgreSQL)
+
+```python
+from madsci.common.db_handlers.postgres_handler import (
+    PostgresHandler,     # ABC
+    SQLAlchemyHandler,   # Real (SQLAlchemy + PostgreSQL)
+    SQLiteHandler,       # Testing (in-memory SQLite)
+)
+
+# Production:
+handler = SQLAlchemyHandler(url="postgresql://localhost/resources")
+engine = handler.get_engine()
+
+# Testing:
+handler = SQLiteHandler()  # StaticPool, check_same_thread=False
+```
+
+**Used by:** Resource manager
+
+### ObjectStorageHandler (S3-compatible)
+
+```python
+from madsci.common.db_handlers.object_storage_handler import (
+    ObjectStorageHandler,          # ABC
+    RealObjectStorageHandler,      # Real (MinIO/SeaweedFS/S3)
+    InMemoryObjectStorageHandler,  # Testing
+)
+
+# Production:
+handler = RealObjectStorageHandler(settings=ObjectStorageSettings(...))
+
+# Testing:
+handler = InMemoryObjectStorageHandler()
+```
+
+**Used by:** Data manager (optional, for file storage)
+
+## Manager-Specific Notes
+
+### Event Manager (8001)
+- **Retention system**: Background loop archives old events (soft-delete), TTL indexes for hard-delete
+- **Utilization analytics**: Session-based, time-series, and per-user utilization reports
+- **Email alerts**: Configurable alert level triggers email notifications
+- **Recursive logging prevention**: EventClient initialized with `event_server_url=None`
+- **Key types**: `Event`, `EventLogLevel`, `EventType`
+
+### Experiment Manager (8002)
+- **Simple state machine**: IN_PROGRESS -> PAUSED/COMPLETED/FAILED/CANCELLED
+- **Timestamp tracking**: `started_at`, `ended_at` on Experiment model
+- **Key types**: `Experiment`, `ExperimentDesign`, `ExperimentStatus`, `ExperimentalCampaign`
+
+### Resource Manager (8003)
+- **Only PostgreSQL manager**: Uses SQLModel ORM, not document database
+- **Container types**: Queue (FIFO), Stack (LIFO), Slot (single item)
+- **Resource hierarchies**: Parent-child relationships with recursive queries
+- **Template system**: Create resources from templates, extract templates from existing resources
+- **Audit trail**: `ResourceHistoryTable` tracks all changes
+- **Key types**: `Resource`, `ResourceTemplate`, `Queue`, `Stack`, `Slot`
+
+### Data Manager (8004)
+- **Dual storage**: Metadata in FerretDB, files in local filesystem or S3-compatible storage
+- **DataPoint discriminated union**: `FileDataPoint`, `ValueDataPoint`, `ObjectStorageDataPoint`
+- **File organization**: Local files stored as `{year}/{month}/{day}/{ulid_filename}`
+- **Key types**: `DataPoint`, `FileDataPoint`, `ValueDataPoint`
+
+### Workcell Manager (8005)
+- **Workflow engine**: Executes workflow DAGs with branching and error recovery
+- **Dual-handler**: FerretDB for workflow definitions, Valkey for runtime state/locks
+- **Required clients**: event, data, location (for workflow execution)
+- **Node coordination**: Discovers and communicates with registered nodes
+- **Key types**: `WorkflowDefinition`, `WorkflowRun`, `WorkflowStep`
+
+### Location Manager (8006)
+- **Dual-handler**: FerretDB for persistent data, Valkey for transient state (locks, counters)
+- **Transfer planning**: Dijkstra's algorithm via `TransferPlanner`
+- **Node-specific representations**: Arbitrary JSON data per node per location
+- **Seed file loading**: Bootstrap from `locations.yaml` on empty database
+- **Key types**: `Location`, `TransferPlan`, `ReservationInfo`
+
+### Lab Manager / Squid (8000)
+- **No database**: Coordination-only, no persistent storage
+- **Service discovery**: `/context` endpoint returns all manager URLs
+- **Health aggregation**: `/lab_health` checks all 6 managers with 5s timeout
+- **Dashboard**: Serves Vue 3 + Vuetify SPA as static files
+- **Key types**: `LabHealth`, `LabContext`
+
+## EventClient Dual Nature
+
+EventClient serves as both a logging interface and an HTTP client:
+
+```python
+# Logging (always works, even without Event Manager)
+self.logger.info("Operation started", event_type=EventType.WORKFLOW_START, workflow_id=wf_id)
+self.logger.warning("Threshold exceeded", value=42.5)
+self.logger.error("Connection failed", error=str(e))
+
+# HTTP client (requires Event Manager)
+events = self.event_client.get_events(number=10)
+event = self.event_client.get_event(event_id)
+```
+
+**Structured logging best practice:**
+```python
+# Good: kwargs are queryable
+self.logger.info("Step completed", step_index=3, duration_ms=150)
+
+# Bad: f-string data is not queryable
+self.logger.info(f"Step 3 completed in 150ms")
+```
+
+## Health Check Pattern
+
+```python
+def get_health(self) -> MyManagerHealth:
+    health = MyManagerHealth(healthy=True)
+    try:
+        health.db_connected = self._document_handler.ping()
+        health.total_items = self._get_count()
+    except Exception as e:
+        health.healthy = False
+        health.description = f"Database error: {e}"
+    return health
+```
+
+`ManagerHealth` uses `model_config = ConfigDict(extra="allow")` so subclasses can freely add fields.
+
+## Testing Managers
+
+```python
+from madsci.common.db_handlers import (
+    InMemoryDocumentStorageHandler,
+    InMemoryCacheHandler,
+    SQLiteHandler,
+)
+
+def test_event_manager():
+    manager = EventManager(
+        settings=EventManagerSettings(enable_registry_resolution=False),
+        document_handler=InMemoryDocumentStorageHandler(),
+    )
+    app = manager.create_server()
+    client = TestClient(app)
+
+    # Test endpoints
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["healthy"] is True
+
+def test_workcell_manager():
+    manager = WorkcellManager(
+        settings=WorkcellManagerSettings(enable_registry_resolution=False),
+        document_handler=InMemoryDocumentStorageHandler(),
+        cache_handler=InMemoryCacheHandler(),
+    )
+    ...
+
+def test_resource_manager():
+    manager = ResourceManager(
+        settings=ResourceManagerSettings(enable_registry_resolution=False),
+        postgres_handler=SQLiteHandler(),
+    )
+    ...
+```
+
+**Critical test pattern:** Always set `enable_registry_resolution=False` to prevent registry lockfile usage in tests.
+
+## OpenTelemetry Integration
+
+Per-manager configuration via environment:
+```bash
+EVENT_OTEL_ENABLED=true
+EVENT_OTEL_SERVICE_NAME="madsci.event"
+EVENT_OTEL_EXPORTER="otlp"           # or "console"
+EVENT_OTEL_ENDPOINT="http://localhost:4317"
+EVENT_OTEL_PROTOCOL="grpc"           # or "http"
+```
+
+In code:
+```python
+with self.span("process_data", attributes={"data.size": 100}) as span:
+    result = process(data)
+    span.set_attribute("result.count", len(result))
+```
+
+## Common Pitfalls
+
+- **ULID not UUID**: Use `new_ulid_str()` for all IDs
+- **prefixed vs unprefixed**: Code uses `self.settings.server_url`, YAML uses `event_server_url`
+- **`model_dump(by_alias=True)`**: Produces prefixed keys for YAML export
+- **Registry in tests**: Always `enable_registry_resolution=False`
+- **Handler injection**: Pass handlers via constructor for dependency injection (production and test)
+- **FerretDB, not MongoDB**: The system uses FerretDB (MongoDB wire protocol on PostgreSQL). pymongo client works unchanged.
+- **Valkey, not Redis**: Drop-in Redis replacement. redis-py client works unchanged.
+- **EventClient recursive logging**: Event Manager's own EventClient must have `event_server_url=None`
+- **AnyUrl trailing slash**: All URLs stored via Pydantic AnyUrl get a trailing slash
+- **Secret fields**: Use `json_schema_extra={"secret": True}` or `SecretStr` type

--- a/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-nodes/SKILL.md
+++ b/src/madsci_common/madsci/common/bundled_templates/_skills/madsci-nodes/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: madsci-nodes
+description: Working with MADSci node modules for laboratory instrument integration. Use when creating, modifying, debugging, or testing node modules that interface with scientific instruments.
+---
+
+# MADSci Node Modules
+
+Node modules are the instrument integration layer of MADSci. Each node wraps a laboratory instrument (robot arm, plate reader, liquid handler, etc.) behind a standard API. The architecture is: **AbstractNode** (protocol-agnostic base) -> **RestNode** (FastAPI HTTP server). Both use **MadsciClientMixin** for lazy access to Event, Resource, and Data clients.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/madsci_node_module/madsci/node_module/abstract_node_module.py` | Base class with lifecycle, action dispatch, type analysis |
+| `src/madsci_node_module/madsci/node_module/rest_node_module.py` | FastAPI server, file upload/download, rate limiting |
+| `src/madsci_node_module/madsci/node_module/helpers.py` | `@action` decorator |
+| `src/madsci_node_module/madsci/node_module/type_analyzer.py` | Recursive type hint analysis (`TypeInfo`) |
+| `src/madsci_common/madsci/common/types/node_types.py` | NodeConfig, RestNodeConfig, NodeStatus, NodeInfo, NodeCapabilities |
+| `src/madsci_client/madsci/client/node/rest_node_client.py` | HTTP client for node communication |
+| `src/madsci_common/madsci/common/bundled_templates/node/basic/` | `madsci new node` template |
+
+## Creating a Node
+
+### 1. Scaffold with template
+```bash
+madsci new node
+# or: madsci new module  (full module with interface, types, tests, Dockerfile)
+```
+
+### 2. Minimal RestNode
+```python
+from madsci.node_module.rest_node_module import RestNode
+from madsci.node_module.helpers import action
+
+class MyInstrumentNode(RestNode):
+    """Node for controlling MyInstrument."""
+
+    def startup_handler(self):
+        """Initialize instrument connections."""
+        self.instrument = MyInstrumentDriver()
+
+    def shutdown_handler(self):
+        """Clean up instrument connections."""
+        self.instrument.disconnect()
+
+    @action(name="measure", description="Take a measurement")
+    def measure(self, sample_id: str, temperature: float = 25.0) -> dict:
+        result = self.instrument.measure(sample_id, temp=temperature)
+        return {"sample_id": sample_id, "value": result}
+
+if __name__ == "__main__":
+    node = MyInstrumentNode()
+    node.start_node()
+```
+
+### 3. Configuration
+Nodes use `NodeConfig` (AbstractNode) or `RestNodeConfig` (RestNode), both inheriting from `MadsciBaseSettings`:
+
+```python
+# RestNodeConfig key fields:
+node_name: Optional[str]       # Human name (defaults to class name)
+node_id: Optional[str]         # ULID (auto-generated)
+node_type: Optional[NodeType]  # DEVICE, COMPUTE, etc.
+node_url: AnyUrl               # Default: http://127.0.0.1:2000
+status_update_interval: float  # Default: 2.0s
+state_update_interval: float   # Default: 2.0s
+enable_registry_resolution: bool  # Default: True
+enable_rate_limiting: bool     # Default: True
+```
+
+Config is discovered via walk-up file search (see CLAUDE.md). Override with environment variables using `NODE_` prefix or pass directly:
+```python
+node = MyNode(node_config=RestNodeConfig(node_url="http://0.0.0.0:3000"))
+```
+
+## The @action Decorator
+
+Register methods as node actions. Discovered automatically at init.
+
+```python
+from madsci.node_module.helpers import action
+
+# With explicit parameters
+@action(name="dispense", description="Dispense liquid", blocking=True)
+def dispense(self, volume_ul: float, well: str) -> dict:
+    ...
+
+# Minimal (name from function, description from docstring, blocking=True)
+@action
+def home(self):
+    """Home all axes to reference position."""
+    self.instrument.home()
+```
+
+**Parameters:**
+- `name` (str, optional): Action name (defaults to function name)
+- `description` (str, optional): Description (defaults to docstring)
+- `blocking` (bool, default `True`): Whether the action blocks concurrent actions via `_action_lock`
+
+**Behind the scenes:** Sets `__is_madsci_action__ = True` on the function. `AbstractNode.__init__()` scans `__class__.__dict__` for this flag and auto-registers via `_add_action()`.
+
+## Action Parameters and Return Types
+
+### Regular parameters
+Standard Python types become JSON-serializable action arguments:
+```python
+@action
+def process(self, sample_id: str, count: int = 1, options: Optional[dict] = None) -> dict:
+    ...
+```
+
+### File parameters (use `Path`, not `UploadFile`)
+```python
+from pathlib import Path
+
+@action
+def analyze_image(self, image: Path) -> dict:
+    """Single file upload."""
+    data = image.read_bytes()
+    return {"size": len(data)}
+
+@action
+def batch_process(self, files: list[Path]) -> dict:
+    """Multiple file upload."""
+    return {"count": len(files)}
+```
+
+### Location parameters
+```python
+from madsci.common.types.location_types import LocationArgument
+
+@action
+def transfer(self, source: LocationArgument, destination: LocationArgument) -> dict:
+    ...
+```
+
+### Annotated parameters (extra metadata)
+```python
+from typing import Annotated
+
+@action
+def calibrate(self, offset: Annotated[float, "Offset in mm, range -10 to 10"]) -> dict:
+    ...
+```
+
+### Return types
+```python
+from madsci.common.types.action_types import ActionFiles, ActionDatapoints
+from madsci.common.types.data_types import DataPoint
+
+# Plain dict/Pydantic model -> json_result
+@action
+def measure(self) -> dict:
+    return {"value": 42}
+
+# Path -> single file result
+@action
+def capture(self) -> Path:
+    return Path("/tmp/image.png")
+
+# ActionFiles -> multiple named files
+@action
+def generate_report(self) -> ActionFiles:
+    return ActionFiles(report=Path("report.pdf"), data=Path("data.csv"))
+
+# Tuple -> (json_result, files, datapoints)
+@action
+def full_result(self) -> tuple[dict, ActionFiles, ActionDatapoints]:
+    return (
+        {"status": "ok"},
+        ActionFiles(output=Path("out.csv")),
+        ActionDatapoints(dp=DataPoint(label="measurement", value=42)),
+    )
+```
+
+## Node Lifecycle
+
+```
+__init__()
+  ├── Load NodeConfig (walk-up discovery)
+  ├── Synthesize NodeInfo
+  ├── Resolve registry identity (if enabled)
+  ├── Configure clients (EventClient, ResourceClient, DataClient)
+  └── Discover @action methods
+
+start_node()
+  ├── Establish event_client_context
+  ├── Log startup
+  └── _startup() thread:
+      ├── startup_handler()       ← Override this
+      ├── template_handler()      ← Override for resource/location templates
+      └── Status/state update loops (every N seconds)
+          ├── status_handler()    ← Override to populate node_status
+          └── state_handler()     ← Override to populate node_state
+
+Per-action execution:
+  ├── Parse args (TypeAnalyzer)
+  ├── Validate required args
+  ├── Check node ready (not busy/locked/errored)
+  ├── Execute in daemon thread (with _action_lock if blocking)
+  ├── Process result -> ActionResult
+  └── Update action_history & log status
+
+shutdown:
+  ├── shutdown_handler()          ← Override for cleanup
+  ├── Release registry identity
+  └── Teardown clients
+```
+
+## REST API Endpoints (RestNode)
+
+### Standard endpoints
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/status` | Node operational status |
+| `GET` | `/info` | Node metadata, actions, capabilities |
+| `GET` | `/state` | Custom state dict |
+| `POST` | `/config` | Update config fields |
+| `GET` | `/log` | EventClient logs |
+| `POST` | `/admin/{command}` | Admin commands (lock, unlock, shutdown) |
+| `GET` | `/action` | Action history |
+
+### Per-action endpoints (3-phase file upload)
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/action/{name}` | Create action, get `action_id` |
+| `POST` | `/action/{name}/{id}/upload/{param}` | Upload file(s) for a parameter |
+| `POST` | `/action/{name}/{id}/start` | Start execution |
+| `GET` | `/action/{name}/{id}/status` | Poll action status |
+| `GET` | `/action/{name}/{id}/result` | Get result (files as key list) |
+| `GET` | `/action/{id}/download` | Download all files as ZIP |
+
+## NodeStatus
+
+```python
+# Operational flags:
+busy: bool          # Currently executing an action
+paused: bool        # Manually paused
+locked: bool        # Locked via admin command
+stopped: bool       # Node stopped
+errored: bool       # Node in error state
+disconnected: bool  # Lost connection
+initializing: bool  # Still starting up
+
+# Computed:
+ready: bool         # True only if no flags set and no waiting_for_config
+description: str    # Human-readable reason if not ready
+```
+
+## Resource/Location Template Registration
+
+Declare templates as ClassVar lists for automatic registration at startup:
+
+```python
+class MyNode(RestNode):
+    resource_templates: ClassVar[list[NodeResourceTemplateDefinition]] = [
+        NodeResourceTemplateDefinition(
+            template_name="sample_plate",
+            description="96-well sample plate",
+            version="1.0",
+        ),
+    ]
+    location_templates: ClassVar[list[NodeLocationTemplateDefinition]] = [
+        NodeLocationTemplateDefinition(
+            template_name="plate_slot",
+            description="Instrument plate slot",
+        ),
+    ]
+
+    def template_handler(self):
+        """Called at startup to register templates. Override for custom logic."""
+        super().template_handler()
+```
+
+## Datapoint Helpers
+
+Upload data to the Data Manager from within actions:
+
+```python
+@action
+def measure(self) -> dict:
+    value = self.instrument.read()
+
+    # Single value datapoint
+    dp_id = self.create_and_upload_value_datapoint(value=value, label="measurement")
+
+    # File datapoint
+    file_id = self.create_and_upload_file_datapoint(
+        file_path=Path("output.csv"), label="raw_data"
+    )
+
+    # Custom datapoint
+    from madsci.common.types.data_types import DataPoint
+    dp = DataPoint(label="custom", value={"nested": "data"})
+    self.upload_datapoint(dp)
+
+    return {"measurement": value, "datapoint_id": dp_id}
+```
+
+## Testing Nodes
+
+```python
+from fastapi.testclient import TestClient
+
+def test_node_action():
+    node = MyInstrumentNode(
+        node_config=RestNodeConfig(
+            enable_registry_resolution=False,  # Critical for tests
+            node_url="http://127.0.0.1:2000",
+        )
+    )
+    node.start_node(testing=True)  # Configures routes without starting uvicorn
+
+    client = TestClient(node.rest_api)
+
+    # Check info
+    response = client.get("/info")
+    assert response.status_code == 200
+    assert "measure" in response.json()["actions"]
+
+    # Run action (no file params)
+    response = client.post("/action/measure", json={"sample_id": "ABC123"})
+    assert response.status_code == 200
+    action_id = response.json()["action_id"]
+
+    # Start and get result
+    client.post(f"/action/measure/{action_id}/start")
+    import time; time.sleep(0.5)
+    result = client.get(f"/action/measure/{action_id}/result")
+    assert result.json()["json_result"]["sample_id"] == "ABC123"
+```
+
+## Common Pitfalls
+
+- **ULID not UUID**: Always use `new_ulid_str()` from `madsci.common.utils` for IDs
+- **Path not UploadFile**: File parameters use `pathlib.Path`, not FastAPI's `UploadFile`
+- **blocking=True by default**: Actions serialize unless you set `blocking=False`
+- **Registry in tests**: Always set `enable_registry_resolution=False` in test configs
+- **Config discovery**: `NodeConfig` walks up directories looking for `settings.yaml`, `node.settings.yaml`, etc. Set `_settings_dir` to control where it looks
+- **Client lazy init**: `self.resource_client`, `self.data_client`, `self.event_client` are created on first access. If the corresponding service is unavailable, the first access will fail
+- **AnyUrl trailing slash**: Pydantic's `AnyUrl` always adds a trailing slash to URLs

--- a/src/madsci_common/madsci/common/bundled_templates/comm/modbus/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/comm/modbus/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A Modbus TCP/RTU communication interface using pymodbus patterns"
 category: "comm"
 tags: ["modbus", "plc", "industrial", "communication"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/comm/rest/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/comm/rest/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A REST API client interface for HTTP-based instrument communication"
 category: "comm"
 tags: ["rest", "http", "api", "communication"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/comm/sdk/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/comm/sdk/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A vendor SDK wrapper interface pattern for instrument communication"
 category: "comm"
 tags: ["sdk", "vendor", "wrapper", "communication"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/comm/serial/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/comm/serial/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A serial port communication interface using pySerial patterns"
 category: "comm"
 tags: ["serial", "rs232", "communication"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/comm/socket/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/comm/socket/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A TCP/UDP socket communication interface"
 category: "comm"
 tags: ["socket", "tcp", "udp", "communication"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/experiment/node/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/experiment/node/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A REST API server experiment using ExperimentNode modality"
 category: "experiment"
 tags: ["node", "server", "rest", "api"]
+skills: ["madsci-experiments"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/experiment/notebook/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/experiment/notebook/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "An interactive Jupyter notebook experiment"
 category: "experiment"
 tags: ["notebook", "jupyter", "interactive"]
+skills: ["madsci-experiments"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/experiment/script/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/experiment/script/template.yaml
@@ -3,6 +3,7 @@ version: "2.0.0"
 description: "A simple run-once experiment script using ExperimentScript modality"
 category: "experiment"
 tags: ["script", "simple", "starter"]
+skills: ["madsci-experiments"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/experiment/tui/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/experiment/tui/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "An interactive terminal UI experiment using ExperimentTUI modality"
 category: "experiment"
 tags: ["tui", "interactive", "terminal"]
+skills: ["madsci-experiments"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/interface/fake/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/interface/fake/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "Add a fake interface for testing without hardware"
 category: "interface"
 tags: ["fake", "testing", "simulation"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/interface/mock/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/interface/mock/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A pytest mock-based interface for unit testing"
 category: "interface"
 tags: ["mock", "testing", "pytest"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/interface/real/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/interface/real/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A real hardware interface stub with connection lifecycle and error handling patterns"
 category: "interface"
 tags: ["real", "hardware", "interface"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/interface/sim/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/interface/sim/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "An interface for connecting to an external device simulator"
 category: "interface"
 tags: ["simulator", "testing", "development"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/lab/distributed/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/lab/distributed/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A distributed lab configuration for multi-host deployments"
 category: "lab"
 tags: ["distributed", "multi-host", "production"]
+skills: ["madsci-nodes", "madsci-experiments", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/lab/minimal/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/lab/minimal/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A minimal lab configuration with no Docker required"
 category: "lab"
 tags: ["minimal", "starter", "no-docker"]
+skills: ["madsci-nodes", "madsci-experiments", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/lab/standard/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/lab/standard/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A standard lab configuration with all managers and Docker Compose infrastructure"
 category: "lab"
 tags: ["standard", "docker", "full-stack"]
+skills: ["madsci-nodes", "madsci-experiments", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/basic/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A minimal MADSci node module with a single example action"
 category: "module"
 tags: ["basic", "starter", "minimal"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/camera/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/camera/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A camera/vision system module with image capture and configuration actions"
 category: "module"
 tags: ["camera", "vision", "imaging"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/device/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/device/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A standard device module with lifecycle actions (initialize, shutdown, status) and resource management"
 category: "module"
 tags: ["device", "lifecycle", "resources"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/instrument/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/instrument/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A measurement instrument module with calibration and data acquisition actions"
 category: "module"
 tags: ["instrument", "measurement", "calibration"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/liquid_handler/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/liquid_handler/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A liquid handling module with aspirate, dispense, and transfer actions"
 category: "module"
 tags: ["liquid-handler", "pipetting", "automation"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/module/robot_arm/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/module/robot_arm/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A robot arm module with pick, place, move, and home actions for material handling"
 category: "module"
 tags: ["robot-arm", "material-handling", "automation"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/node/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/node/basic/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A standalone REST node server for an existing interface"
 category: "node"
 tags: ["basic", "standalone", "minimal"]
+skills: ["madsci-nodes"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A basic workcell configuration"
 category: "workcell"
 tags: ["basic", "starter"]
-skills: ["madsci-managers", "madsci-cli"]
+skills: ["madsci-nodes", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A basic workcell configuration"
 category: "workcell"
 tags: ["basic", "starter"]
+skills: ["madsci-managers"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workcell/basic/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A basic workcell configuration"
 category: "workcell"
 tags: ["basic", "starter"]
-skills: ["madsci-managers"]
+skills: ["madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A simple single-step workflow"
 category: "workflow"
 tags: ["basic", "simple", "starter"]
-skills: ["madsci-managers", "madsci-cli"]
+skills: ["madsci-nodes", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A simple single-step workflow"
 category: "workflow"
 tags: ["basic", "simple", "starter"]
-skills: ["madsci-managers"]
+skills: ["madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/basic/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A simple single-step workflow"
 category: "workflow"
 tags: ["basic", "simple", "starter"]
+skills: ["madsci-managers"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
@@ -3,6 +3,7 @@ version: "1.0.0"
 description: "A multi-step workflow with sequential node actions"
 category: "workflow"
 tags: ["multi-step", "sequential", "workflow"]
+skills: ["madsci-managers"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A multi-step workflow with sequential node actions"
 category: "workflow"
 tags: ["multi-step", "sequential", "workflow"]
-skills: ["madsci-managers"]
+skills: ["madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
+++ b/src/madsci_common/madsci/common/bundled_templates/workflow/multi_step/template.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 description: "A multi-step workflow with sequential node actions"
 category: "workflow"
 tags: ["multi-step", "sequential", "workflow"]
-skills: ["madsci-managers", "madsci-cli"]
+skills: ["madsci-nodes", "madsci-managers", "madsci-cli"]
 
 author: "MADSci Team"
 license: "MIT"

--- a/src/madsci_common/madsci/common/templates/engine.py
+++ b/src/madsci_common/madsci/common/templates/engine.py
@@ -182,7 +182,9 @@ class TemplateEngine:
         Returns:
             Path to _skills/ directory, or None if not found.
         """
-        # Walk up from template_dir looking for _skills/ sibling
+        # Walk up from template_dir looking for _skills/ sibling.
+        # Bundled templates are at most 2-3 levels deep (e.g.
+        # bundled_templates/module/device/), so 5 levels is sufficient.
         current = self.template_dir
         for _ in range(5):
             candidate = current / "_skills"
@@ -204,6 +206,50 @@ class TemplateEngine:
             pass
 
         return None
+
+    def _copy_skills(
+        self,
+        output_dir: Path,
+        dry_run: bool,
+    ) -> tuple[list[Path], list[str]]:
+        """Copy declared agent skills into the generated project.
+
+        Args:
+            output_dir: Directory to write skill files into.
+            dry_run: If True, track paths but don't write files.
+
+        Returns:
+            Tuple of (files_created, skills_included).
+        """
+        files_created: list[Path] = []
+        skills_included: list[str] = []
+
+        if not self.manifest.skills:
+            return files_created, skills_included
+
+        skills_dir = self._resolve_skills_dir()
+        if not skills_dir:
+            logger.warning("Skills directory not found, skipping skill copying")
+            return files_created, skills_included
+
+        for skill_name in self.manifest.skills:
+            skill_source = skills_dir / skill_name / "SKILL.md"
+            if not skill_source.is_file():
+                logger.warning("Skill not found, skipping: skill_name=%s", skill_name)
+                continue
+            skill_dest = output_dir / ".agents" / "skills" / skill_name / "SKILL.md"
+            if not dry_run:
+                skill_dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(skill_source, skill_dest)
+                logger.debug(
+                    "Copied skill: skill_name=%s dest=%s",
+                    skill_name,
+                    str(skill_dest),
+                )
+            files_created.append(skill_dest)
+            skills_included.append(skill_name)
+
+        return files_created, skills_included
 
     def validate_parameters(self, values: dict[str, Any]) -> list[str]:  # noqa: C901, PLR0912
         """Validate parameter values against manifest.
@@ -309,7 +355,7 @@ class TemplateEngine:
 
         return defaults
 
-    def render(  # noqa: C901, PLR0912, PLR0915
+    def render(  # noqa: C901, PLR0912
         self,
         output_dir: Path,
         parameters: dict[str, Any],
@@ -401,32 +447,8 @@ class TemplateEngine:
             files_created.append(dest_full)
 
         # Copy agent skills
-        skills_included: list[str] = []
-        if self.manifest.skills:
-            skills_dir = self._resolve_skills_dir()
-            if skills_dir:
-                for skill_name in self.manifest.skills:
-                    skill_source = skills_dir / skill_name / "SKILL.md"
-                    if not skill_source.is_file():
-                        logger.warning(
-                            "Skill not found, skipping: skill_name=%s", skill_name
-                        )
-                        continue
-                    skill_dest = (
-                        output_dir / ".agents" / "skills" / skill_name / "SKILL.md"
-                    )
-                    if not dry_run:
-                        skill_dest.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(skill_source, skill_dest)
-                        logger.debug(
-                            "Copied skill: skill_name=%s dest=%s",
-                            skill_name,
-                            str(skill_dest),
-                        )
-                    files_created.append(skill_dest)
-                    skills_included.append(skill_name)
-            else:
-                logger.warning("Skills directory not found, skipping skill copying")
+        skill_files, skills_included = self._copy_skills(output_dir, dry_run)
+        files_created.extend(skill_files)
 
         # Run post-generation hooks
         hooks_executed: list[str] = []

--- a/src/madsci_common/madsci/common/templates/engine.py
+++ b/src/madsci_common/madsci/common/templates/engine.py
@@ -4,6 +4,7 @@ Template engine for MADSci.
 This module provides the engine for rendering templates into generated projects.
 """
 
+import importlib.resources
 import logging
 import re
 import shlex
@@ -172,6 +173,38 @@ class TemplateEngine:
 
         return env
 
+    def _resolve_skills_dir(self) -> Path | None:
+        """Resolve the _skills/ directory containing bundled agent skills.
+
+        Walks up from the template directory to find _skills/ in bundled_templates,
+        falling back to importlib.resources for installed packages.
+
+        Returns:
+            Path to _skills/ directory, or None if not found.
+        """
+        # Walk up from template_dir looking for _skills/ sibling
+        current = self.template_dir
+        for _ in range(5):
+            candidate = current.parent / "_skills"
+            if candidate.is_dir():
+                return candidate
+            current = current.parent
+
+        # Fallback: use importlib.resources
+        try:
+            resource = (
+                importlib.resources.files("madsci.common")
+                / "bundled_templates"
+                / "_skills"
+            )
+            path = Path(str(resource))
+            if path.is_dir():
+                return path
+        except (TypeError, FileNotFoundError):
+            pass
+
+        return None
+
     def validate_parameters(self, values: dict[str, Any]) -> list[str]:  # noqa: C901, PLR0912
         """Validate parameter values against manifest.
 
@@ -276,7 +309,7 @@ class TemplateEngine:
 
         return defaults
 
-    def render(  # noqa: C901, PLR0912
+    def render(  # noqa: C901, PLR0912, PLR0915
         self,
         output_dir: Path,
         parameters: dict[str, Any],
@@ -367,6 +400,34 @@ class TemplateEngine:
 
             files_created.append(dest_full)
 
+        # Copy agent skills
+        skills_included: list[str] = []
+        if self.manifest.skills:
+            skills_dir = self._resolve_skills_dir()
+            if skills_dir:
+                for skill_name in self.manifest.skills:
+                    skill_source = skills_dir / skill_name / "SKILL.md"
+                    if not skill_source.is_file():
+                        logger.warning(
+                            "Skill not found, skipping: skill_name=%s", skill_name
+                        )
+                        continue
+                    skill_dest = (
+                        output_dir / ".agents" / "skills" / skill_name / "SKILL.md"
+                    )
+                    if not dry_run:
+                        skill_dest.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(skill_source, skill_dest)
+                        logger.debug(
+                            "Copied skill: skill_name=%s dest=%s",
+                            skill_name,
+                            str(skill_dest),
+                        )
+                    files_created.append(skill_dest)
+                    skills_included.append(skill_name)
+            else:
+                logger.warning("Skills directory not found, skipping skill copying")
+
         # Run post-generation hooks
         hooks_executed: list[str] = []
         if not dry_run and self.manifest.hooks:
@@ -407,4 +468,5 @@ class TemplateEngine:
             files_created=files_created,
             parameters_used=values,
             hooks_executed=hooks_executed,
+            skills_included=skills_included,
         )

--- a/src/madsci_common/madsci/common/templates/engine.py
+++ b/src/madsci_common/madsci/common/templates/engine.py
@@ -185,7 +185,7 @@ class TemplateEngine:
         # Walk up from template_dir looking for _skills/ sibling
         current = self.template_dir
         for _ in range(5):
-            candidate = current.parent / "_skills"
+            candidate = current / "_skills"
             if candidate.is_dir():
                 return candidate
             current = current.parent

--- a/src/madsci_common/madsci/common/types/template_types.py
+++ b/src/madsci_common/madsci/common/types/template_types.py
@@ -121,6 +121,10 @@ class TemplateManifest(MadsciBaseModel):
         description="Category (module, node, experiment, etc.)"
     )
     tags: list[str] = Field(default_factory=list, description="Search tags")
+    skills: list[str] = Field(
+        default_factory=list,
+        description="Agent skill names to include in generated project",
+    )
 
     # Optional metadata
     author: Optional[str] = Field(default=None, description="Template author")
@@ -162,6 +166,10 @@ class GeneratedProject(MadsciBaseModel):
     )
     hooks_executed: list[str] = Field(
         default_factory=list, description="Hooks that were executed"
+    )
+    skills_included: list[str] = Field(
+        default_factory=list,
+        description="Agent skills copied into the generated project",
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc),

--- a/src/madsci_common/tests/test_templates/test_template_engine.py
+++ b/src/madsci_common/tests/test_templates/test_template_engine.py
@@ -5,6 +5,7 @@ the registry discovers templates, and generated code is valid.
 """
 
 import ast
+import importlib.resources
 from pathlib import Path
 
 import pytest
@@ -800,9 +801,8 @@ class TestTemplateRendering:
             parameters={"experiment_name": "my_exp"},
         )
 
-        assert len(result.files_created) == 1
-        py_file = result.files_created[0]
-        assert py_file.name == "my_exp.py"
+        assert len(result.files_created) == 2  # 1 script + 1 skill
+        py_file = next(f for f in result.files_created if f.name == "my_exp.py")
         assert py_file.exists()
 
         # Verify syntax
@@ -823,9 +823,8 @@ class TestTemplateRendering:
             parameters={"experiment_name": "my_tui_exp"},
         )
 
-        assert len(result.files_created) == 1
-        py_file = result.files_created[0]
-        assert py_file.name == "my_tui_exp_tui.py"
+        assert len(result.files_created) == 2  # 1 script + 1 skill
+        py_file = next(f for f in result.files_created if f.name == "my_tui_exp_tui.py")
         assert py_file.exists()
 
         content = py_file.read_text()
@@ -846,9 +845,10 @@ class TestTemplateRendering:
             parameters={"experiment_name": "my_node_exp", "server_port": 7000},
         )
 
-        assert len(result.files_created) == 1
-        py_file = result.files_created[0]
-        assert py_file.name == "my_node_exp_node.py"
+        assert len(result.files_created) == 2  # 1 script + 1 skill
+        py_file = next(
+            f for f in result.files_created if f.name == "my_node_exp_node.py"
+        )
         assert py_file.exists()
 
         content = py_file.read_text()
@@ -874,9 +874,10 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 1
-        yaml_file = result.files_created[0]
-        assert yaml_file.name == "my_wf.workflow.yaml"
+        assert len(result.files_created) == 2  # 1 workflow + 1 skill
+        yaml_file = next(
+            f for f in result.files_created if f.name == "my_wf.workflow.yaml"
+        )
         assert yaml_file.exists()
 
         content = yaml_file.read_text()
@@ -902,9 +903,10 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 1
-        yaml_file = result.files_created[0]
-        assert yaml_file.name == "transfer_wf.workflow.yaml"
+        assert len(result.files_created) == 2  # 1 workflow + 1 skill
+        yaml_file = next(
+            f for f in result.files_created if f.name == "transfer_wf.workflow.yaml"
+        )
         assert yaml_file.exists()
 
         content = yaml_file.read_text()
@@ -988,7 +990,7 @@ class TestTemplateRendering:
             parameters={"lab_name": "test_lab"},
         )
 
-        assert len(result.files_created) == 7
+        assert len(result.files_created) == 11  # 7 files + 4 skills
         file_names = [f.name for f in result.files_created]
         assert "start_lab.py" in file_names
         assert "settings.yaml" in file_names
@@ -1011,7 +1013,7 @@ class TestTemplateRendering:
             parameters={"lab_name": "test_lab"},
         )
 
-        assert len(result.files_created) == 8
+        assert len(result.files_created) == 12  # 8 files + 4 skills
         file_names = [f.name for f in result.files_created]
         assert "start_lab.py" in file_names
         assert "settings.yaml" in file_names
@@ -1035,7 +1037,7 @@ class TestTemplateRendering:
             parameters={"lab_name": "test_lab"},
         )
 
-        assert len(result.files_created) == 9
+        assert len(result.files_created) == 13  # 9 files + 4 skills
         file_names = [f.name for f in result.files_created]
         assert "start_lab.py" in file_names
         assert "settings.yaml" in file_names
@@ -1260,3 +1262,206 @@ class TestTemplateCompleteness:
                         f"Invalid Python syntax in {f.name} "
                         f"(template: {template_id}): {e}"
                     )
+
+
+# --- Skills copying tests ---
+
+
+class TestSkillsCopying:
+    """Test that agent skills are correctly copied into generated projects."""
+
+    @pytest.fixture
+    def registry(self, tmp_path: Path) -> TemplateRegistry:
+        return TemplateRegistry(user_template_dir=tmp_path / "user_templates")
+
+    def test_skills_copied_for_module_template(
+        self, registry: TemplateRegistry, tmp_path: Path
+    ) -> None:
+        """Module templates should include the madsci-nodes skill."""
+        engine = registry.get_template("module/basic")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        engine.render(
+            output_dir=output_dir,
+            parameters={"module_name": "test_mod", "port": 2000},
+        )
+
+        skill_file = output_dir / ".agents" / "skills" / "madsci-nodes" / "SKILL.md"
+        assert skill_file.exists()
+        content = skill_file.read_text()
+        assert "madsci-nodes" in content
+
+    def test_skills_copied_for_experiment_template(
+        self, registry: TemplateRegistry, tmp_path: Path
+    ) -> None:
+        """Experiment templates should include the madsci-experiments skill."""
+        engine = registry.get_template("experiment/script")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        engine.render(
+            output_dir=output_dir,
+            parameters={"experiment_name": "test_exp"},
+        )
+
+        skill_file = (
+            output_dir / ".agents" / "skills" / "madsci-experiments" / "SKILL.md"
+        )
+        assert skill_file.exists()
+        content = skill_file.read_text()
+        assert "madsci-experiments" in content
+
+    def test_skills_copied_for_lab_template(
+        self, registry: TemplateRegistry, tmp_path: Path
+    ) -> None:
+        """Lab templates should include all 4 skills."""
+        engine = registry.get_template("lab/minimal")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        engine.render(
+            output_dir=output_dir,
+            parameters={"lab_name": "test_lab"},
+        )
+
+        for skill_name in [
+            "madsci-nodes",
+            "madsci-experiments",
+            "madsci-managers",
+            "madsci-cli",
+        ]:
+            skill_file = output_dir / ".agents" / "skills" / skill_name / "SKILL.md"
+            assert skill_file.exists(), f"Missing skill: {skill_name}"
+
+    def test_skills_dry_run(self, registry: TemplateRegistry, tmp_path: Path) -> None:
+        """Skills should be listed in files_created but not written during dry run."""
+        engine = registry.get_template("module/basic")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = engine.render(
+            output_dir=output_dir,
+            parameters={"module_name": "test_mod", "port": 2000},
+            dry_run=True,
+        )
+
+        skill_paths = [f for f in result.files_created if "SKILL.md" in f.name]
+        assert len(skill_paths) == 1
+        # File should NOT exist on disk
+        assert not skill_paths[0].exists()
+
+    def test_skills_included_in_result(
+        self, registry: TemplateRegistry, tmp_path: Path
+    ) -> None:
+        """Result should list skill names in skills_included."""
+        engine = registry.get_template("lab/minimal")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = engine.render(
+            output_dir=output_dir,
+            parameters={"lab_name": "test_lab"},
+        )
+
+        assert sorted(result.skills_included) == sorted(
+            [
+                "madsci-nodes",
+                "madsci-experiments",
+                "madsci-managers",
+                "madsci-cli",
+            ]
+        )
+
+    def test_no_skills_when_empty(self, tmp_path: Path) -> None:
+        """Template with no skills field should copy nothing."""
+        # Create a minimal template with no skills
+        template_dir = tmp_path / "template"
+        template_dir.mkdir()
+        manifest = (
+            'name: "Test"\n'
+            'version: "1.0.0"\n'
+            'description: "Test template"\n'
+            'category: "module"\n'
+            "tags: []\n"
+            "skills: []\n"
+            "parameters: []\n"
+            "files: []\n"
+        )
+        (template_dir / "template.yaml").write_text(manifest)
+
+        engine = TemplateEngine(template_dir)
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = engine.render(output_dir=output_dir, parameters={})
+
+        assert result.skills_included == []
+        skill_dir = output_dir / ".agents" / "skills"
+        assert not skill_dir.exists()
+
+    @pytest.mark.parametrize(
+        "template_id",
+        [
+            "module/basic",
+            "module/device",
+            "module/camera",
+            "module/instrument",
+            "module/liquid_handler",
+            "module/robot_arm",
+            "interface/fake",
+            "interface/real",
+            "interface/sim",
+            "interface/mock",
+            "node/basic",
+            "experiment/script",
+            "experiment/notebook",
+            "experiment/tui",
+            "experiment/node",
+            "workflow/basic",
+            "workflow/multi_step",
+            "workcell/basic",
+            "lab/minimal",
+            "lab/standard",
+            "lab/distributed",
+            "comm/serial",
+            "comm/socket",
+            "comm/rest",
+            "comm/sdk",
+            "comm/modbus",
+        ],
+    )
+    def test_all_templates_declare_skills(
+        self, registry: TemplateRegistry, template_id: str
+    ) -> None:
+        """Every bundled template should have at least one skill declared."""
+        engine = registry.get_template(template_id)
+        assert len(engine.manifest.skills) > 0, (
+            f"Template {template_id} has no skills declared"
+        )
+
+    def test_bundled_skills_match_repo_skills(self) -> None:
+        """Bundled _skills/ content should match .agents/skills/ (via symlinks)."""
+        bundled_skills = (
+            Path(str(importlib.resources.files("madsci.common")))
+            / "bundled_templates"
+            / "_skills"
+        )
+        repo_skills = Path(__file__).resolve().parents[4] / ".agents" / "skills"
+
+        if not repo_skills.exists():
+            pytest.skip("Repo .agents/skills/ not found (installed package test)")
+
+        for skill_name in [
+            "madsci-nodes",
+            "madsci-experiments",
+            "madsci-managers",
+            "madsci-cli",
+        ]:
+            bundled_file = bundled_skills / skill_name / "SKILL.md"
+            repo_file = repo_skills / skill_name / "SKILL.md"
+            assert bundled_file.exists(), f"Missing bundled skill: {skill_name}"
+            assert repo_file.exists(), f"Missing repo skill: {skill_name}"
+            assert bundled_file.read_text() == repo_file.read_text(), (
+                f"Content mismatch for {skill_name}/SKILL.md"
+            )

--- a/src/madsci_common/tests/test_templates/test_template_engine.py
+++ b/src/madsci_common/tests/test_templates/test_template_engine.py
@@ -874,7 +874,7 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 3  # 1 workflow + 2 skills
+        assert len(result.files_created) == 4  # 1 workflow + 3 skills
         yaml_file = next(
             f for f in result.files_created if f.name == "my_wf.workflow.yaml"
         )
@@ -903,7 +903,7 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 3  # 1 workflow + 2 skills
+        assert len(result.files_created) == 4  # 1 workflow + 3 skills
         yaml_file = next(
             f for f in result.files_created if f.name == "transfer_wf.workflow.yaml"
         )
@@ -1440,6 +1440,29 @@ class TestSkillsCopying:
             f"Template {template_id} has no skills declared"
         )
 
+    def test_resolve_skills_dir_importlib_fallback(self, tmp_path: Path) -> None:
+        """_resolve_skills_dir falls back to importlib.resources for isolated templates."""
+        # Create a template in an isolated directory with no _skills/ ancestor
+        template_dir = tmp_path / "isolated" / "deep" / "template"
+        template_dir.mkdir(parents=True)
+        (template_dir / "template.yaml").write_text(
+            'name: "Test"\n'
+            'version: "1.0.0"\n'
+            'description: "Test"\n'
+            'category: "module"\n'
+            "tags: []\n"
+            'skills: ["madsci-nodes"]\n'
+            "parameters: []\n"
+            "files: []\n"
+        )
+
+        engine = TemplateEngine(template_dir)
+        skills_dir = engine._resolve_skills_dir()
+
+        assert skills_dir is not None
+        assert skills_dir.is_dir()
+        assert (skills_dir / "madsci-nodes" / "SKILL.md").exists()
+
     def test_bundled_skills_match_repo_skills(self) -> None:
         """Bundled _skills/ content should match .agents/skills/ (via symlinks)."""
         bundled_skills = (
@@ -1447,8 +1470,17 @@ class TestSkillsCopying:
             / "bundled_templates"
             / "_skills"
         )
-        repo_skills = Path(__file__).resolve().parents[4] / ".agents" / "skills"
 
+        # Walk up from this file to find the repo root via .git/
+        repo_root = Path(__file__).resolve()
+        while repo_root != repo_root.parent:
+            if (repo_root / ".git").is_dir():
+                break
+            repo_root = repo_root.parent
+        else:
+            pytest.skip("Could not find repo root (.git directory)")
+
+        repo_skills = repo_root / ".agents" / "skills"
         if not repo_skills.exists():
             pytest.skip("Repo .agents/skills/ not found (installed package test)")
 

--- a/src/madsci_common/tests/test_templates/test_template_engine.py
+++ b/src/madsci_common/tests/test_templates/test_template_engine.py
@@ -874,7 +874,7 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 2  # 1 workflow + 1 skill
+        assert len(result.files_created) == 3  # 1 workflow + 2 skills
         yaml_file = next(
             f for f in result.files_created if f.name == "my_wf.workflow.yaml"
         )
@@ -903,7 +903,7 @@ class TestTemplateRendering:
             },
         )
 
-        assert len(result.files_created) == 2  # 1 workflow + 1 skill
+        assert len(result.files_created) == 3  # 1 workflow + 2 skills
         yaml_file = next(
             f for f in result.files_created if f.name == "transfer_wf.workflow.yaml"
         )


### PR DESCRIPTION
## Summary

- Generated projects now automatically include relevant agent skills (`.agents/skills/`) so coding agents have MADSci domain knowledge from day one
- Added `skills` field to `TemplateManifest` and `skills_included` to `GeneratedProject`; `TemplateEngine.render()` copies SKILL.md files from a shared `_skills/` directory in `bundled_templates/`
- All 26 template manifests declare category-appropriate skills: module/node/interface/comm get `madsci-nodes`, experiment gets `madsci-experiments`, workflow/workcell get `madsci-managers` + `madsci-cli`, lab gets all 4

## Changes

**Core:**
- `template_types.py`: New `skills` and `skills_included` fields
- `engine.py`: `_resolve_skills_dir()` + skill-copy logic in `render()` (dry-run aware)
- `bundled_templates/_skills/`: Canonical location for 4 SKILL.md files
- `.agents/skills/madsci-*`: Replaced directories with symlinks to bundled copies

**Templates:** All 26 `template.yaml` files updated with `skills:` field

**CLI:** `madsci init` now prints skill count after rendering; refactored into helper functions

**Docs:** Updated `template_catalog.md` (bundled skills table) and `agent_skills.md` (generated project section)

**Tests:** New `TestSkillsCopying` class with 8 tests (copy, dry-run, result tracking, all-templates-declare, bundled-matches-repo) + updated file-count assertions

## Test plan

- [x] `pytest src/madsci_common/tests/test_templates/` — 183 tests pass
- [x] `pytest` full suite — 2929 tests pass
- [x] `just all` pipeline passes (checks, tests, build, docs)
- [x] Symlinks resolve correctly in `.agents/skills/` and `.claude/skills/`
- [x] Manual: `madsci init --no-interactive` in temp dir, verify `.agents/skills/` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)