### PR TITLE
fix: initialize action argument values from defaults in node modal

### DIFF
--- a/ui/src/components/NodeModal.vue
+++ b/ui/src/components/NodeModal.vue
@@ -76,7 +76,11 @@
                 <p class="py-1 my-1">{{ action.description }}</p>
                 <h5 v-if="Object.keys(action.args).length > 0">Arguments</h5>
                 <v-data-table v-if="Object.keys(action.args).length > 0" :headers="arg_headers" :items="Object.keys(action.args).map(function(key){
-    return action.args[key];})" hover items-per-page="-1"
+    const arg = action.args[key];
+    if (arg.value === undefined && arg.default !== undefined && arg.default !== null) {
+      arg.value = arg.default;
+    }
+    return arg;})" hover items-per-page="-1"
                   no-data-text="No Arguments" density="compact">
                   <!-- eslint-disable vue/no-parsing-error-->
                   <template v-slot:item="{ item }: { item: any }">
@@ -88,7 +92,7 @@
                       <td>{{ item.description }}</td>
                       <td>
                         <template v-if="item.argument_type === 'bool'">
-                          <v-checkbox v-model="item.value" :true-value="true" :false-value="false" :value="item.value ?? false" hide-details density="compact"/>
+                          <v-checkbox v-model="item.value" :true-value="true" :false-value="false" hide-details density="compact"/>
                         </template>
                         <template v-else-if="['int', 'float'].includes(item.argument_type)">
                           <v-text-field v-model.number="item.value" type="number" density="compact" hide-details/>


### PR DESCRIPTION
## Summary
- Fixes checkboxes on the node modal not reflecting the default values of action arguments (#190)
- When action arguments are rendered, `item.value` is now initialized from `item.default` if the value hasn't been set yet
- Removes redundant `:value` prop from v-checkbox (unnecessary with v-model + `:true-value`/`:false-value`)

## Details
The `ArgumentDefinition` objects from the backend include a `default` field, but the frontend never used it to initialize the editable `value` field. This caused boolean checkboxes to always appear unchecked regardless of the action's declared default. The fix also benefits text and number fields by pre-filling them with their defaults.

## Test plan
- [x] Open the dashboard and navigate to a node modal with boolean action arguments
- [x] Verify checkboxes reflect the correct default values (checked if `default: true`, unchecked if `default: false`)
- [x] Verify text and number fields also show their default values pre-filled
- [x] Verify that manually changing a value still works correctly
- [x] Verify "Send Action" and "Show Copyable Workflow Step" still use the correct values

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)