### PR TITLE
fix: propagate experiment ownership context to workflows

### DIFF
--- a/docs/api/madsci/experiment_application/experiment_base.md
+++ b/docs/api/madsci/experiment_application/experiment_base.md
@@ -10,6 +10,19 @@ The key design principle is composition over inheritance: ExperimentBase
 uses MadsciClientMixin for client management rather than inheriting from
 RestNode, making it lighter weight for non-server use cases.
 
+Functions
+---------
+
+`clear_experiment_ownership() ‑> None`
+:   Clear experiment-specific ownership fields from global ownership info.
+
+`set_experiment_ownership(experiment: Experiment) ‑> None`
+:   Set experiment ownership fields on the global ownership info.
+    
+    Called after an experiment run is started so that downstream code
+    (e.g., WorkcellClient.start_workflow) picks up the experiment context
+    via get_current_ownership_info().
+
 Classes
 -------
 

--- a/src/madsci_experiment_application/madsci/experiment_application/experiment_application.py
+++ b/src/madsci_experiment_application/madsci/experiment_application/experiment_application.py
@@ -26,6 +26,7 @@ from madsci.common.context import (
     set_current_madsci_context,
 )
 from madsci.common.exceptions import ExperimentCancelledError, ExperimentFailedError
+from madsci.common.ownership import ownership_context
 from madsci.common.types.base_types import PathLike
 from madsci.common.types.condition_types import Condition
 from madsci.common.types.event_types import EventType
@@ -38,6 +39,10 @@ from madsci.common.types.location_types import Location
 from madsci.common.types.node_types import RestNodeConfig
 from madsci.common.types.resource_types import Resource
 from madsci.common.utils import threaded_daemon
+from madsci.experiment_application.experiment_base import (
+    clear_experiment_ownership,
+    set_experiment_ownership,
+)
 from madsci.node_module.rest_node_module import RestNode
 from pydantic import AnyUrl, Field
 from rich import print
@@ -214,6 +219,8 @@ class ExperimentApplication(RestNode):
             run_name=self.experiment.run_name,
             experiment_name=self.experiment.experiment_design.experiment_name,
         )
+        set_experiment_ownership(self.experiment)
+
         passed_checks = False
         while not passed_checks:
             passed_checks = True
@@ -247,6 +254,8 @@ class ExperimentApplication(RestNode):
             experiment_name=self.experiment.experiment_design.experiment_name,
             status=str(status) if status is not None else None,
         )
+
+        clear_experiment_ownership()
 
     def pause_experiment(self) -> None:
         """Pause the experiment."""
@@ -316,7 +325,7 @@ class ExperimentApplication(RestNode):
         """
         self.start_experiment_run(run_name=run_name, run_description=run_description)
 
-        # Establish experiment context for hierarchical logging
+        # Establish experiment context for hierarchical logging and ownership tracking
         experiment_id = self.experiment.experiment_id if self.experiment else None
         experiment_name = (
             self.experiment.experiment_design.experiment_name
@@ -324,12 +333,27 @@ class ExperimentApplication(RestNode):
             else None
         )
 
-        with event_client_context(
-            name="experiment",
-            experiment_id=experiment_id,
-            experiment_name=experiment_name,
-            run_name=run_name,
-            experiment_type=self.__class__.__name__,
+        # Build ownership overrides from the experiment's ownership info
+        ownership_overrides: dict = {}
+        if experiment_id:
+            ownership_overrides["experiment_id"] = experiment_id
+        if self.experiment and self.experiment.ownership_info:
+            exp_ownership = self.experiment.ownership_info.model_dump(exclude_none=True)
+            # Merge experiment ownership fields (campaign_id, user_id, etc.)
+            # without overriding the experiment_id we just set
+            for key, value in exp_ownership.items():
+                if key not in ownership_overrides:
+                    ownership_overrides[key] = value
+
+        with (
+            ownership_context(**ownership_overrides),
+            event_client_context(
+                name="experiment",
+                experiment_id=experiment_id,
+                experiment_name=experiment_name,
+                run_name=run_name,
+                experiment_type=self.__class__.__name__,
+            ),
         ):
             try:
                 yield

--- a/src/madsci_experiment_application/madsci/experiment_application/experiment_application.py
+++ b/src/madsci_experiment_application/madsci/experiment_application/experiment_application.py
@@ -40,6 +40,7 @@ from madsci.common.types.node_types import RestNodeConfig
 from madsci.common.types.resource_types import Resource
 from madsci.common.utils import threaded_daemon
 from madsci.experiment_application.experiment_base import (
+    _EXPERIMENT_OWNERSHIP_FIELDS,
     clear_experiment_ownership,
     set_experiment_ownership,
 )
@@ -333,17 +334,16 @@ class ExperimentApplication(RestNode):
             else None
         )
 
-        # Build ownership overrides from the experiment's ownership info
+        # Build ownership overrides from the experiment's ownership info,
+        # restricted to experiment-level fields only
         ownership_overrides: dict = {}
         if experiment_id:
             ownership_overrides["experiment_id"] = experiment_id
         if self.experiment and self.experiment.ownership_info:
-            exp_ownership = self.experiment.ownership_info.model_dump(exclude_none=True)
-            # Merge experiment ownership fields (campaign_id, user_id, etc.)
-            # without overriding the experiment_id we just set
-            for key, value in exp_ownership.items():
-                if key not in ownership_overrides:
-                    ownership_overrides[key] = value
+            for field in _EXPERIMENT_OWNERSHIP_FIELDS:
+                value = getattr(self.experiment.ownership_info, field, None)
+                if value is not None and field not in ownership_overrides:
+                    ownership_overrides[field] = value
 
         with (
             ownership_context(**ownership_overrides),

--- a/src/madsci_experiment_application/madsci/experiment_application/experiment_base.py
+++ b/src/madsci_experiment_application/madsci/experiment_application/experiment_base.py
@@ -524,17 +524,16 @@ class ExperimentBase(MadsciClientMixin):
             else None
         )
 
-        # Build ownership overrides from the experiment's ownership info
+        # Build ownership overrides from the experiment's ownership info,
+        # restricted to experiment-level fields only
         ownership_overrides: dict = {}
         if experiment_id:
             ownership_overrides["experiment_id"] = experiment_id
         if self.experiment and self.experiment.ownership_info:
-            exp_ownership = self.experiment.ownership_info.model_dump(exclude_none=True)
-            # Merge experiment ownership fields (campaign_id, user_id, etc.)
-            # without overriding the experiment_id we just set
-            for key, value in exp_ownership.items():
-                if key not in ownership_overrides:
-                    ownership_overrides[key] = value
+            for field in _EXPERIMENT_OWNERSHIP_FIELDS:
+                value = getattr(self.experiment.ownership_info, field, None)
+                if value is not None and field not in ownership_overrides:
+                    ownership_overrides[field] = value
 
         with (
             ownership_context(**ownership_overrides),

--- a/src/madsci_experiment_application/madsci/experiment_application/experiment_base.py
+++ b/src/madsci_experiment_application/madsci/experiment_application/experiment_base.py
@@ -26,6 +26,7 @@ from madsci.common.exceptions import (
     ExperimentFailedError,
     ExperimentPauseTimeoutError,
 )
+from madsci.common.ownership import global_ownership_info, ownership_context
 from madsci.common.types.base_types import MadsciBaseSettings, PathLike
 from madsci.common.types.event_types import EventType
 from madsci.common.types.experiment_types import (
@@ -37,6 +38,33 @@ from pydantic import AnyUrl, Field
 
 if TYPE_CHECKING:
     from madsci.common.types.context_types import MadsciContext
+
+_EXPERIMENT_OWNERSHIP_FIELDS = ("campaign_id", "user_id", "project_id")
+
+
+def set_experiment_ownership(experiment: "Experiment") -> None:
+    """Set experiment ownership fields on the global ownership info.
+
+    Called after an experiment run is started so that downstream code
+    (e.g., WorkcellClient.start_workflow) picks up the experiment context
+    via get_current_ownership_info().
+    """
+    if not isinstance(getattr(experiment, "experiment_id", None), str):
+        return
+    global_ownership_info.experiment_id = experiment.experiment_id
+    ownership_info = getattr(experiment, "ownership_info", None)
+    if ownership_info:
+        for field in _EXPERIMENT_OWNERSHIP_FIELDS:
+            value = getattr(ownership_info, field, None)
+            if isinstance(value, str):
+                setattr(global_ownership_info, field, value)
+
+
+def clear_experiment_ownership() -> None:
+    """Clear experiment-specific ownership fields from global ownership info."""
+    global_ownership_info.experiment_id = None
+    for field in _EXPERIMENT_OWNERSHIP_FIELDS:
+        setattr(global_ownership_info, field, None)
 
 
 class ExperimentBaseConfig(
@@ -335,6 +363,8 @@ class ExperimentBase(MadsciClientMixin):
             experiment_name=experiment_name,
         )
 
+        set_experiment_ownership(self.experiment)
+
         return self.experiment
 
     def end_experiment(
@@ -380,6 +410,8 @@ class ExperimentBase(MadsciClientMixin):
             experiment_name=experiment_name,
             status=str(status) if status else "completed",
         )
+
+        clear_experiment_ownership()
 
         return self.experiment
 
@@ -484,7 +516,7 @@ class ExperimentBase(MadsciClientMixin):
         """
         self.start_experiment_run(run_name=run_name, run_description=run_description)
 
-        # Build context for hierarchical logging
+        # Build context for hierarchical logging and ownership tracking
         experiment_id = self.experiment.experiment_id if self.experiment else None
         experiment_name = (
             self.experiment.experiment_design.experiment_name
@@ -492,12 +524,27 @@ class ExperimentBase(MadsciClientMixin):
             else None
         )
 
-        with event_client_context(
-            name="experiment",
-            experiment_id=experiment_id,
-            experiment_name=experiment_name,
-            run_name=run_name,
-            experiment_type=self.__class__.__name__,
+        # Build ownership overrides from the experiment's ownership info
+        ownership_overrides: dict = {}
+        if experiment_id:
+            ownership_overrides["experiment_id"] = experiment_id
+        if self.experiment and self.experiment.ownership_info:
+            exp_ownership = self.experiment.ownership_info.model_dump(exclude_none=True)
+            # Merge experiment ownership fields (campaign_id, user_id, etc.)
+            # without overriding the experiment_id we just set
+            for key, value in exp_ownership.items():
+                if key not in ownership_overrides:
+                    ownership_overrides[key] = value
+
+        with (
+            ownership_context(**ownership_overrides),
+            event_client_context(
+                name="experiment",
+                experiment_id=experiment_id,
+                experiment_name=experiment_name,
+                run_name=run_name,
+                experiment_type=self.__class__.__name__,
+            ),
         ):
             try:
                 yield self

--- a/src/madsci_experiment_application/tests/test_experiment_application.py
+++ b/src/madsci_experiment_application/tests/test_experiment_application.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from madsci.common.exceptions import ExperimentCancelledError, ExperimentFailedError
+from madsci.common.ownership import get_current_ownership_info, global_ownership_info
+from madsci.common.types.auth_types import OwnershipInfo
 from madsci.common.types.condition_types import (
     NoResourceInLocationCondition,
     ResourceChildFieldCheckCondition,
@@ -902,6 +904,238 @@ class TestExperimentManagement:
             experiment_id=experiment_app_with_mocks.experiment.experiment_id,
             status=ExperimentStatus.FAILED,
         )
+
+
+class TestExperimentOwnershipPropagation:
+    """Test that ownership context is properly set within manage_experiment."""
+
+    def test_manage_experiment_sets_ownership_context(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that manage_experiment establishes ownership_context with experiment_id."""
+        captured_ownership = None
+
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+            experiment_app_with_mocks.manage_experiment(run_name="ownership_test"),
+        ):
+            captured_ownership = get_current_ownership_info()
+
+        assert captured_ownership is not None
+        assert (
+            captured_ownership.experiment_id
+            == experiment_app_with_mocks.experiment.experiment_id
+        )
+
+    def test_manage_experiment_propagates_campaign_id(
+        self,
+    ) -> None:
+        """Test that manage_experiment propagates campaign_id from experiment ownership."""
+        campaign_id = new_ulid_str()
+
+        mock_experiment = Experiment(
+            run_name="campaign_test",
+            experiment_design=ExperimentDesign(
+                experiment_name="Campaign_Test",
+                resource_conditions=[],
+            ),
+            ownership_info=OwnershipInfo(campaign_id=campaign_id),
+            status=ExperimentStatus.IN_PROGRESS,
+        )
+        # Capture the actual experiment_id assigned by the model
+        experiment_id = mock_experiment.experiment_id
+
+        with mock_all_clients():
+            app = TestExperimentApplication(
+                node_config=ExperimentApplicationConfig(
+                    enable_registry_resolution=False
+                ),
+                experiment_design=ExperimentDesign(
+                    experiment_name="Campaign_Test",
+                    resource_conditions=[],
+                ),
+            )
+            app.event_client = Mock()
+            app.logger = app.event_client
+            app.experiment_client = Mock()
+            app.experiment_client.start_experiment.return_value = mock_experiment
+            app.experiment_client.end_experiment.return_value = mock_experiment
+            app.workcell_client = Mock()
+
+            captured_ownership = None
+            with (
+                patch("builtins.input", return_value="n"),
+                patch("builtins.print"),
+                app.manage_experiment(run_name="campaign_test"),
+            ):
+                captured_ownership = get_current_ownership_info()
+
+            assert captured_ownership is not None
+            assert captured_ownership.experiment_id == experiment_id
+            assert captured_ownership.campaign_id == campaign_id
+
+    def test_ownership_context_cleared_after_manage_experiment(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that ownership context is restored after manage_experiment exits."""
+        ownership_before = get_current_ownership_info()
+
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+            experiment_app_with_mocks.manage_experiment(run_name="cleanup_test"),
+        ):
+            pass
+
+        ownership_after = get_current_ownership_info()
+        assert ownership_after.experiment_id == ownership_before.experiment_id
+
+    def test_ownership_context_cleared_on_exception(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that ownership context is restored even when an exception occurs."""
+        ownership_before = get_current_ownership_info()
+
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+            pytest.raises(ValueError),
+            experiment_app_with_mocks.manage_experiment(run_name="exception_test"),
+        ):
+            raise ValueError("Test error")
+
+        ownership_after = get_current_ownership_info()
+        assert ownership_after.experiment_id == ownership_before.experiment_id
+
+    def test_ownership_visible_to_get_current_ownership_info(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that downstream code calling get_current_ownership_info gets experiment data.
+
+        This simulates the pattern used by WorkcellClient.start_workflow(),
+        which calls get_current_ownership_info() to attach ownership to workflows.
+        """
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+            experiment_app_with_mocks.manage_experiment(run_name="downstream_test"),
+        ):
+            # Simulate what WorkcellClient.start_workflow() does
+            ownership = get_current_ownership_info()
+            dumped = ownership.model_dump(exclude_none=True)
+
+            assert "experiment_id" in dumped
+            assert (
+                dumped["experiment_id"]
+                == experiment_app_with_mocks.experiment.experiment_id
+            )
+
+
+class TestStartEndOwnershipPropagation:
+    """Test that ownership context is properly set with the manual start/end pattern.
+
+    This covers the ExperimentNotebook pattern where start() and end()
+    are called in separate notebook cells without manage_experiment().
+    """
+
+    def test_start_sets_global_ownership(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that start_experiment_run sets experiment_id on global ownership."""
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+        ):
+            experiment_app_with_mocks.start_experiment_run(run_name="global_test")
+
+            assert (
+                global_ownership_info.experiment_id
+                == experiment_app_with_mocks.experiment.experiment_id
+            )
+
+            # Clean up
+            experiment_app_with_mocks.end_experiment()
+
+    def test_end_clears_global_ownership(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that end_experiment clears experiment_id from global ownership."""
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+        ):
+            experiment_app_with_mocks.start_experiment_run(run_name="cleanup_test")
+            assert global_ownership_info.experiment_id is not None
+
+            experiment_app_with_mocks.end_experiment()
+            assert global_ownership_info.experiment_id is None
+
+    def test_start_propagates_campaign_id_to_global(self) -> None:
+        """Test that campaign_id from experiment ownership is set on global."""
+        campaign_id = new_ulid_str()
+
+        mock_experiment = Experiment(
+            run_name="campaign_global_test",
+            experiment_design=ExperimentDesign(
+                experiment_name="Campaign_Global_Test",
+                resource_conditions=[],
+            ),
+            ownership_info=OwnershipInfo(campaign_id=campaign_id),
+            status=ExperimentStatus.IN_PROGRESS,
+        )
+
+        with mock_all_clients():
+            app = TestExperimentApplication(
+                node_config=ExperimentApplicationConfig(
+                    enable_registry_resolution=False
+                ),
+                experiment_design=ExperimentDesign(
+                    experiment_name="Campaign_Global_Test",
+                    resource_conditions=[],
+                ),
+            )
+            app.event_client = Mock()
+            app.logger = app.event_client
+            app.experiment_client = Mock()
+            app.experiment_client.start_experiment.return_value = mock_experiment
+            app.experiment_client.end_experiment.return_value = mock_experiment
+
+            app.start_experiment_run(run_name="campaign_global_test")
+
+            assert global_ownership_info.experiment_id == mock_experiment.experiment_id
+            assert global_ownership_info.campaign_id == campaign_id
+
+            # Clean up
+            app.end_experiment()
+            assert global_ownership_info.campaign_id is None
+
+    def test_get_current_ownership_info_between_start_end(
+        self, experiment_app_with_mocks: TestExperimentApplication
+    ) -> None:
+        """Test that get_current_ownership_info returns experiment data between start/end.
+
+        This simulates the notebook pattern where WorkcellClient.start_workflow()
+        is called between start() and end() without manage_experiment().
+        """
+        with (
+            patch("builtins.input", return_value="n"),
+            patch("builtins.print"),
+        ):
+            experiment_app_with_mocks.start_experiment_run(run_name="notebook_test")
+
+            # Simulate what WorkcellClient.start_workflow() does
+            ownership = get_current_ownership_info()
+            dumped = ownership.model_dump(exclude_none=True)
+
+            assert "experiment_id" in dumped
+            assert (
+                dumped["experiment_id"]
+                == experiment_app_with_mocks.experiment.experiment_id
+            )
+
+            # Clean up
+            experiment_app_with_mocks.end_experiment()
 
 
 class TestClassMethods:

--- a/src/madsci_experiment_application/tests/test_experiment_application.py
+++ b/src/madsci_experiment_application/tests/test_experiment_application.py
@@ -1048,14 +1048,13 @@ class TestStartEndOwnershipPropagation:
             patch("builtins.print"),
         ):
             experiment_app_with_mocks.start_experiment_run(run_name="global_test")
-
-            assert (
-                global_ownership_info.experiment_id
-                == experiment_app_with_mocks.experiment.experiment_id
-            )
-
-            # Clean up
-            experiment_app_with_mocks.end_experiment()
+            try:
+                assert (
+                    global_ownership_info.experiment_id
+                    == experiment_app_with_mocks.experiment.experiment_id
+                )
+            finally:
+                experiment_app_with_mocks.end_experiment()
 
     def test_end_clears_global_ownership(
         self, experiment_app_with_mocks: TestExperimentApplication
@@ -1066,10 +1065,14 @@ class TestStartEndOwnershipPropagation:
             patch("builtins.print"),
         ):
             experiment_app_with_mocks.start_experiment_run(run_name="cleanup_test")
-            assert global_ownership_info.experiment_id is not None
-
-            experiment_app_with_mocks.end_experiment()
-            assert global_ownership_info.experiment_id is None
+            try:
+                assert global_ownership_info.experiment_id is not None
+                experiment_app_with_mocks.end_experiment()
+                assert global_ownership_info.experiment_id is None
+            finally:
+                # Ensure cleanup even if assertions fail
+                if global_ownership_info.experiment_id is not None:
+                    experiment_app_with_mocks.end_experiment()
 
     def test_start_propagates_campaign_id_to_global(self) -> None:
         """Test that campaign_id from experiment ownership is set on global."""
@@ -1102,12 +1105,13 @@ class TestStartEndOwnershipPropagation:
             app.experiment_client.end_experiment.return_value = mock_experiment
 
             app.start_experiment_run(run_name="campaign_global_test")
-
-            assert global_ownership_info.experiment_id == mock_experiment.experiment_id
-            assert global_ownership_info.campaign_id == campaign_id
-
-            # Clean up
-            app.end_experiment()
+            try:
+                assert (
+                    global_ownership_info.experiment_id == mock_experiment.experiment_id
+                )
+                assert global_ownership_info.campaign_id == campaign_id
+            finally:
+                app.end_experiment()
             assert global_ownership_info.campaign_id is None
 
     def test_get_current_ownership_info_between_start_end(
@@ -1123,19 +1127,18 @@ class TestStartEndOwnershipPropagation:
             patch("builtins.print"),
         ):
             experiment_app_with_mocks.start_experiment_run(run_name="notebook_test")
+            try:
+                # Simulate what WorkcellClient.start_workflow() does
+                ownership = get_current_ownership_info()
+                dumped = ownership.model_dump(exclude_none=True)
 
-            # Simulate what WorkcellClient.start_workflow() does
-            ownership = get_current_ownership_info()
-            dumped = ownership.model_dump(exclude_none=True)
-
-            assert "experiment_id" in dumped
-            assert (
-                dumped["experiment_id"]
-                == experiment_app_with_mocks.experiment.experiment_id
-            )
-
-            # Clean up
-            experiment_app_with_mocks.end_experiment()
+                assert "experiment_id" in dumped
+                assert (
+                    dumped["experiment_id"]
+                    == experiment_app_with_mocks.experiment.experiment_id
+                )
+            finally:
+                experiment_app_with_mocks.end_experiment()
 
 
 class TestClassMethods:


### PR DESCRIPTION
## Summary
- Workflows submitted by experiment applications were not getting `experiment_id`, `campaign_id`, or other ownership fields because ownership context was never established during experiment runs
- Fixed both the `manage_experiment()` context manager path (scripts) and the manual `start()`/`end()` path (notebooks)
- Added shared `set_experiment_ownership()`/`clear_experiment_ownership()` helpers used by both `ExperimentBase` and the deprecated `ExperimentApplication`

## Changes
- **`experiment_base.py`**: Added module-level ownership helpers, `ownership_context` in `manage_experiment()`, ownership calls in `start_experiment_run()`/`end_experiment()`
- **`experiment_application.py`**: Same ownership propagation in the overridden lifecycle methods
- **`test_experiment_application.py`**: 9 new regression tests covering both `manage_experiment()` and `start()`/`end()` patterns

## Test plan
- [x] All 106 experiment application tests pass
- [x] Ruff checks clean
- [x] Pre-commit hooks pass
- [x] Run `just validate_nb_experiment` to verify ownership propagation end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)