### PR TITLE
fix: prevent object storage overwrites on repeated uploads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.2
+    rev: 0.9.1
     hooks:
       - id: nbstripout
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.9
+    rev: v0.15.10
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -13,12 +13,12 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://gitlab.com/bmares/check-json5
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
     - id: check-json5
   - repo: https://github.com/jag-k/pydantic-settings-export
     # Use a tag version with the `v` prefix (e.g. v1.0.0)
-    rev: v1.0.3
+    rev: v1.1.2
     hooks:
      - id: pydantic-settings-export
        entry: pdm run pydantic-settings-export

--- a/src/madsci_client/madsci/client/data_client.py
+++ b/src/madsci_client/madsci/client/data_client.py
@@ -305,6 +305,7 @@ class DataClient:
                     label=datapoint.label,
                     metadata={"original_datapoint_id": datapoint.datapoint_id},
                     timeout=timeout,
+                    datapoint_id=datapoint.datapoint_id,
                 )
 
                 # If object storage upload was successful, return the result
@@ -353,6 +354,7 @@ class DataClient:
         label: Optional[str] = None,
         public_endpoint: Optional[str] = None,
         timeout: Optional[float] = None,
+        datapoint_id: Optional[str] = None,
     ) -> DataPoint:
         """Internal method to upload a file to object storage and create a datapoint.
 
@@ -376,6 +378,11 @@ class DataClient:
             raise ValueError("Object storage is not configured.")
 
         # Use the helper function to upload the file
+        naming_strategy = (
+            ObjectNamingStrategy.ULID_PREFIXED
+            if datapoint_id
+            else ObjectNamingStrategy.FILENAME_ONLY
+        )
         object_storage_info = upload_file_to_object_storage(
             storage_client=self._minio_client,
             object_storage_settings=self.object_storage_settings,
@@ -384,9 +391,10 @@ class DataClient:
             object_name=object_name,
             content_type=content_type,
             metadata=metadata,
-            naming_strategy=ObjectNamingStrategy.FILENAME_ONLY,  # Client uses simple naming
+            naming_strategy=naming_strategy,
             public_endpoint=public_endpoint,
             label=label,
+            ulid=datapoint_id,
         )
 
         if object_storage_info is None:

--- a/src/madsci_common/madsci/common/object_storage_helpers.py
+++ b/src/madsci_common/madsci/common/object_storage_helpers.py
@@ -18,6 +18,7 @@ class ObjectNamingStrategy(Enum):
 
     FILENAME_ONLY = "filename_only"  # Just use the filename
     TIMESTAMPED_PATH = "timestamped_path"  # year/month/day/filename structure
+    ULID_PREFIXED = "ulid_prefixed"  # {ulid}_{filename} structure
 
 
 def _normalise_endpoint(endpoint: str, secure: bool) -> tuple[str, bool]:
@@ -126,6 +127,7 @@ def generate_object_name(
     filename: str,
     strategy: ObjectNamingStrategy = ObjectNamingStrategy.FILENAME_ONLY,
     prefix: Optional[str] = None,
+    ulid: Optional[str] = None,
 ) -> str:
     """Generate an object name using the specified strategy.
 
@@ -133,11 +135,16 @@ def generate_object_name(
         filename: The original filename
         strategy: Naming strategy to use
         prefix: Optional prefix to add to the object name
+        ulid: ULID to use as a prefix (required for ULID_PREFIXED strategy)
 
     Returns:
         Generated object name
     """
-    if strategy == ObjectNamingStrategy.TIMESTAMPED_PATH:
+    if strategy == ObjectNamingStrategy.ULID_PREFIXED:
+        if not ulid:
+            raise ValueError("ULID_PREFIXED strategy requires a ulid parameter")
+        base_name = f"{ulid}_{filename}"
+    elif strategy == ObjectNamingStrategy.TIMESTAMPED_PATH:
         time = datetime.now()
         base_name = f"{time.year}/{time.month}/{time.day}/{filename}"
     else:  # FILENAME_ONLY
@@ -185,6 +192,7 @@ def upload_file_to_object_storage(
     public_endpoint: Optional[str] = None,
     label: Optional[str] = None,
     object_storage_settings: Optional[ObjectStorageSettings] = None,
+    ulid: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     """Upload a file to S3-compatible storage and return storage information.
 
@@ -225,7 +233,9 @@ def upload_file_to_object_storage(
 
     # Use defaults if not specified
     bucket_name = bucket_name or object_storage_settings.default_bucket
-    object_name = object_name or generate_object_name(file_path.name, naming_strategy)
+    object_name = object_name or generate_object_name(
+        file_path.name, naming_strategy, ulid=ulid
+    )
     content_type = content_type or get_content_type(file_path)
     label = label or file_path.name
 

--- a/src/madsci_common/tests/test_object_storage_helpers.py
+++ b/src/madsci_common/tests/test_object_storage_helpers.py
@@ -1,0 +1,55 @@
+"""Tests for object storage helper functions."""
+
+import pytest
+from madsci.common.object_storage_helpers import (
+    ObjectNamingStrategy,
+    generate_object_name,
+)
+
+
+class TestGenerateObjectName:
+    """Tests for generate_object_name with all naming strategies."""
+
+    def test_filename_only(self):
+        result = generate_object_name("data.csv", ObjectNamingStrategy.FILENAME_ONLY)
+        assert result == "data.csv"
+
+    def test_filename_only_with_prefix(self):
+        result = generate_object_name(
+            "data.csv", ObjectNamingStrategy.FILENAME_ONLY, prefix="uploads"
+        )
+        assert result == "uploads/data.csv"
+
+    def test_timestamped_path(self):
+        result = generate_object_name("data.csv", ObjectNamingStrategy.TIMESTAMPED_PATH)
+        # Should contain year/month/day/filename structure
+        parts = result.split("/")
+        assert len(parts) == 4
+        assert parts[-1] == "data.csv"
+
+    def test_ulid_prefixed(self):
+        ulid = "01HXYZ1234567890ABCDEFGH"
+        result = generate_object_name(
+            "data.csv", ObjectNamingStrategy.ULID_PREFIXED, ulid=ulid
+        )
+        assert result == f"{ulid}_data.csv"
+
+    def test_ulid_prefixed_with_prefix(self):
+        ulid = "01HXYZ1234567890ABCDEFGH"
+        result = generate_object_name(
+            "data.csv",
+            ObjectNamingStrategy.ULID_PREFIXED,
+            prefix="uploads",
+            ulid=ulid,
+        )
+        assert result == f"uploads/{ulid}_data.csv"
+
+    def test_ulid_prefixed_without_ulid_raises(self):
+        with pytest.raises(ValueError, match="ULID_PREFIXED strategy requires a ulid"):
+            generate_object_name("data.csv", ObjectNamingStrategy.ULID_PREFIXED)
+
+    def test_ulid_prefixed_with_empty_ulid_raises(self):
+        with pytest.raises(ValueError, match="ULID_PREFIXED strategy requires a ulid"):
+            generate_object_name(
+                "data.csv", ObjectNamingStrategy.ULID_PREFIXED, ulid=""
+            )

--- a/src/madsci_data_manager/madsci/data_manager/data_server.py
+++ b/src/madsci_data_manager/madsci/data_manager/data_server.py
@@ -171,6 +171,7 @@ class DataManager(AbstractManagerBase[DataManagerSettings]):
         self,
         file_path: Path,
         filename: str,
+        datapoint_id: str,
         label: Optional[str] = None,
         metadata: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
@@ -181,7 +182,7 @@ class DataManager(AbstractManagerBase[DataManagerSettings]):
         oss = self._object_storage_settings or ObjectStorageSettings()
         bucket_name = oss.default_bucket
         self._object_storage_handler.ensure_bucket(bucket_name)
-        object_name = label or filename
+        object_name = datapoint_id + "_" + (label or filename)
         result = self._object_storage_handler.upload_file(
             bucket=bucket_name,
             object_name=object_name,
@@ -254,6 +255,7 @@ class DataManager(AbstractManagerBase[DataManagerSettings]):
                         object_storage_info = self._upload_file_to_object_storage(
                             file_path=temp_path,
                             filename=file.filename,
+                            datapoint_id=datapoint_obj.datapoint_id,
                             label=datapoint_obj.label,
                             metadata={
                                 "original_datapoint_id": datapoint_obj.datapoint_id

--- a/src/madsci_data_manager/madsci/data_manager/data_server.py
+++ b/src/madsci_data_manager/madsci/data_manager/data_server.py
@@ -21,7 +21,11 @@ from madsci.common.db_handlers.object_storage_handler import (
 )
 from madsci.common.document_db_version_checker import DocumentDBVersionChecker
 from madsci.common.manager_base import AbstractManagerBase
-from madsci.common.object_storage_helpers import create_object_storage_client
+from madsci.common.object_storage_helpers import (
+    ObjectNamingStrategy,
+    create_object_storage_client,
+    generate_object_name,
+)
 from madsci.common.types.datapoint_types import (
     DataManagerHealth,
     DataManagerSettings,
@@ -182,7 +186,11 @@ class DataManager(AbstractManagerBase[DataManagerSettings]):
         oss = self._object_storage_settings or ObjectStorageSettings()
         bucket_name = oss.default_bucket
         self._object_storage_handler.ensure_bucket(bucket_name)
-        object_name = datapoint_id + "_" + (label or filename)
+        object_name = generate_object_name(
+            label or filename,
+            ObjectNamingStrategy.ULID_PREFIXED,
+            ulid=datapoint_id,
+        )
         result = self._object_storage_handler.upload_file(
             bucket=bucket_name,
             object_name=object_name,

--- a/src/madsci_data_manager/tests/test_data_client.py
+++ b/src/madsci_data_manager/tests/test_data_client.py
@@ -397,7 +397,10 @@ def test_object_storage_from_file_datapoint(tmp_path: Path, object_storage_confi
     # Verify object storage specifics
     if uploaded_datapoint.data_type.value == "object_storage":
         assert uploaded_datapoint.bucket_name == "madsci-test", "Wrong bucket name"
-        assert uploaded_datapoint.object_name == file_path.name, "Wrong object name"
+        assert (
+            uploaded_datapoint.object_name
+            == f"{file_datapoint.datapoint_id}_{file_path.name}"
+        ), "Wrong object name"
     else:
         # Even if data_type still shows as "file", check if it has object storage attributes
         pytest.xfail(

--- a/src/madsci_data_manager/tests/test_data_server.py
+++ b/src/madsci_data_manager/tests/test_data_server.py
@@ -460,8 +460,9 @@ def test_file_datapoint_with_object_storage(document_handler, tmp_path: Path) ->
 
         # Verify the fput_object call arguments
         call_args = mock_minio_client.fput_object.call_args
+        expected_object_name = f"{test_datapoint.datapoint_id}_test_minio_file"
         assert call_args[1]["bucket_name"] == "madsci-test"
-        assert call_args[1]["object_name"] == "test_minio_file"
+        assert call_args[1]["object_name"] == expected_object_name
         assert call_args[1]["content_type"] == "text/plain"
 
         # Verify the returned datapoint has object storage fields and correct data_type
@@ -473,13 +474,15 @@ def test_file_datapoint_with_object_storage(document_handler, tmp_path: Path) ->
         assert "etag" in result
 
         assert result["bucket_name"] == "madsci-test"
-        assert result["object_name"] == "test_minio_file"
+        assert result["object_name"] == expected_object_name
         assert result["storage_endpoint"] == "localhost:8333"
         assert result["etag"] == "test-etag-123"
         assert (
             "localhost:8333" in result["url"]
         )  # Uses same endpoint when no public_endpoint set
-        assert result["url"] == "http://localhost:8333/madsci-test/test_minio_file"
+        assert (
+            result["url"] == f"http://localhost:8333/madsci-test/{expected_object_name}"
+        )
 
         # Verify we can retrieve the datapoint with object storage info
         retrieved_result = test_client.get(
@@ -488,6 +491,60 @@ def test_file_datapoint_with_object_storage(document_handler, tmp_path: Path) ->
         assert retrieved_result["data_type"] == "object_storage"
         assert retrieved_result["bucket_name"] == "madsci-test"
         assert retrieved_result["object_name"] == result["object_name"]
+
+
+def test_object_storage_unique_keys_for_same_label(
+    document_handler, tmp_path: Path
+) -> None:
+    """Regression test: two uploads with the same label must get distinct object keys."""
+    mock_minio_client = MagicMock()
+    mock_minio_client.bucket_exists.return_value = True
+    mock_minio_client.fput_object.return_value = MagicMock(etag="etag-1")
+
+    with patch(
+        "madsci.common.object_storage_helpers.Minio", return_value=mock_minio_client
+    ):
+        settings = DataManagerSettings(
+            manager_name="test_unique_keys",
+            enable_registry_resolution=False,
+        )
+        manager = DataManager(
+            settings=settings,
+            document_handler=document_handler,
+            object_storage_settings=ObjectStorageSettings(
+                endpoint="localhost:8333",
+                access_key="minioadmin",
+                secret_key="minioadmin",
+                secure=False,
+                default_bucket="madsci-test",
+            ),
+        )
+        app = manager.create_server()
+        test_client = TestClient(app)
+
+        # Upload two files with the same label but different content
+        object_names = []
+        for i in range(2):
+            test_file = tmp_path / f"file_{i}.txt"
+            test_file.write_text(f"content {i}")
+
+            dp = FileDataPoint(label="same_label", path=test_file)
+            result = test_client.post(
+                "/datapoint",
+                data={"datapoint": dp.model_dump_json()},
+                files={("files", (str(test_file.name), test_file.open("rb")))},
+            ).json()
+
+            assert result["data_type"] == "object_storage"
+            object_names.append(result["object_name"])
+
+        # The two object names must be different (ULID prefix ensures uniqueness)
+        assert object_names[0] != object_names[1], (
+            "Object names should be unique to prevent overwrites"
+        )
+        # Both should still contain the human-readable label
+        for name in object_names:
+            assert "same_label" in name
 
 
 @pytest.mark.skipif(not is_docker_available(), reason="Docker not available")
@@ -546,7 +603,7 @@ def test_real_object_storage_upload(
     # Verify the response indicates object storage
     assert result["data_type"] == "object_storage"
     assert result["bucket_name"] == "test-bucket"
-    assert result["object_name"] == "real_minio_test"
+    assert result["object_name"] == f"{test_datapoint.datapoint_id}_real_minio_test"
     assert result["size_bytes"] == len(test_content)
     assert "url" in result
 


### PR DESCRIPTION
## Summary
- Object storage uploads used only the label/filename as the S3 object key, causing silent overwrites when the same label was reused across workflow submissions
- Added `ULID_PREFIXED` naming strategy to `ObjectNamingStrategy` and incorporated `datapoint_id` into object keys (`{ulid}_{label}`) in both server-side and client-side upload paths
- This matches the local filesystem backend, which already prefixes filenames with the datapoint ULID

Closes #274

## Test plan
- [x] New `test_object_storage_helpers.py` with 7 unit tests for all naming strategies
- [x] New regression test `test_object_storage_unique_keys_for_same_label` verifying two uploads with the same label produce distinct object keys
- [x] Updated existing assertions in `test_data_server.py` and `test_data_client.py` to expect ULID-prefixed object names
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)