### PR TITLE
fix: Guard against concurrent refresh_data calls in auto-refresh

### DIFF
--- a/src/madsci_client/madsci/client/cli/tui/app.py
+++ b/src/madsci_client/madsci/client/cli/tui/app.py
@@ -5,11 +5,11 @@ Main Textual application for the MADSci terminal user interface.
 
 from __future__ import annotations
 
-import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 from madsci.client.cli.tui.constants import AUTO_REFRESH_INTERVAL, get_default_services
+from madsci.client.cli.tui.refresh_coordinator import ScreenRefreshCoordinator
 from madsci.client.cli.tui.screens.dashboard import DashboardScreen
 from madsci.client.cli.tui.screens.data_browser import DataBrowserScreen
 from madsci.client.cli.tui.screens.experiments import ExperimentsScreen
@@ -86,6 +86,7 @@ class MadsciApp(App):
         self._initial_screen = initial_screen
         self.context = context
         self.service_urls = get_default_services(context)
+        self._refresh_coordinator = ScreenRefreshCoordinator()
 
     def compose(self) -> ComposeResult:
         """Compose the application layout."""
@@ -103,12 +104,7 @@ class MadsciApp(App):
 
     async def _auto_refresh_active_screen(self) -> None:
         """Auto-refresh the active screen if it supports and enables auto-refresh."""
-        screen = self.screen
-        if getattr(screen, "auto_refresh_enabled", False) and hasattr(
-            screen, "refresh_data"
-        ):
-            with contextlib.suppress(Exception):
-                await screen.refresh_data()
+        await self._refresh_coordinator.refresh(self.screen)
 
     def action_switch_screen(self, screen: str) -> None:
         """Switch to a named screen.
@@ -146,5 +142,5 @@ class MadsciApp(App):
         """Refresh the current screen."""
         screen = self.screen
         if hasattr(screen, "refresh_data"):
-            await screen.refresh_data()
+            await self._refresh_coordinator.force_refresh(screen)
             self.notify("Refreshed", timeout=2)

--- a/src/madsci_client/madsci/client/cli/tui/refresh_coordinator.py
+++ b/src/madsci_client/madsci/client/cli/tui/refresh_coordinator.py
@@ -1,0 +1,72 @@
+"""Screen refresh coordinator for MADSci TUI.
+
+Provides :class:`ScreenRefreshCoordinator`, which guards against concurrent
+auto-refresh calls on the same screen.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+
+class ScreenRefreshCoordinator:
+    """Coordinates auto-refresh calls across TUI screens.
+
+    Tracks which screens are currently refreshing to prevent concurrent
+    ``refresh_data()`` calls on the same screen when the auto-refresh timer
+    fires faster than a screen can complete its refresh.
+
+    Usage::
+
+        coordinator = ScreenRefreshCoordinator()
+        await coordinator.refresh(self.screen)
+    """
+
+    def __init__(self) -> None:
+        """Initialize the coordinator with an empty set of refreshing screens."""
+        self._refreshing_screens: set[int] = set()
+
+    async def force_refresh(self, screen: object) -> None:
+        """Force a refresh of a screen, bypassing the in-progress guard.
+
+        Unlike :meth:`refresh`, this method always executes ``refresh_data()``
+        and registers the screen as refreshing to prevent concurrent
+        auto-refresh calls while it runs. Exceptions are not suppressed.
+
+        Args:
+            screen: The TUI screen to refresh.
+        """
+        if not hasattr(screen, "refresh_data"):
+            return
+        screen_id = id(screen)
+        self._refreshing_screens.add(screen_id)
+        try:
+            await screen.refresh_data()
+        finally:
+            self._refreshing_screens.discard(screen_id)
+
+    async def refresh(self, screen: object) -> None:
+        """Refresh a screen if eligible and not already refreshing.
+
+        A screen is eligible if it has ``auto_refresh_enabled`` set to
+        ``True`` and a ``refresh_data()`` coroutine method. If a refresh
+        is already in progress for this screen, the call is silently
+        skipped. Exceptions raised by ``refresh_data()`` are suppressed.
+
+        Args:
+            screen: The active TUI screen to refresh.
+        """
+        if not (
+            getattr(screen, "auto_refresh_enabled", False)
+            and hasattr(screen, "refresh_data")
+        ):
+            return
+        screen_id = id(screen)
+        if screen_id in self._refreshing_screens:
+            return
+        self._refreshing_screens.add(screen_id)
+        try:
+            with contextlib.suppress(Exception):
+                await screen.refresh_data()
+        finally:
+            self._refreshing_screens.discard(screen_id)

--- a/src/madsci_client/tests/cli/test_refresh_coordinator.py
+++ b/src/madsci_client/tests/cli/test_refresh_coordinator.py
@@ -1,0 +1,148 @@
+"""Tests for ScreenRefreshCoordinator."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from madsci.client.cli.tui.refresh_coordinator import ScreenRefreshCoordinator
+
+
+class TestScreenRefreshCoordinator:
+    """Tests for ScreenRefreshCoordinator."""
+
+    def _make_screen(self, refresh_data=None) -> MagicMock:
+        """Return a mock screen with auto_refresh_enabled=True and a refresh_data method."""
+        screen = MagicMock()
+        screen.auto_refresh_enabled = True
+        screen.refresh_data = refresh_data or AsyncMock()
+        return screen
+
+    @pytest.mark.asyncio
+    async def test_refresh_data_is_called(self) -> None:
+        """refresh_data() should be called on an eligible screen."""
+        screen = self._make_screen()
+        coordinator = ScreenRefreshCoordinator()
+
+        await coordinator.refresh(screen)
+
+        screen.refresh_data.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_call_is_skipped(self) -> None:
+        """A second concurrent refresh on the same screen should be skipped."""
+        call_count = 0
+
+        async def slow_refresh() -> None:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+
+        screen = self._make_screen(refresh_data=slow_refresh)
+        coordinator = ScreenRefreshCoordinator()
+
+        await asyncio.gather(
+            coordinator.refresh(screen),
+            coordinator.refresh(screen),
+        )
+
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_different_screens_refresh_independently(self) -> None:
+        """Two different screens should each be refreshed, regardless of the other."""
+        screen_a = self._make_screen()
+        screen_b = self._make_screen()
+        coordinator = ScreenRefreshCoordinator()
+
+        await asyncio.gather(
+            coordinator.refresh(screen_a),
+            coordinator.refresh(screen_b),
+        )
+
+        screen_a.refresh_data.assert_awaited_once()
+        screen_b.refresh_data.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_screen_eligible_again_after_completion(self) -> None:
+        """A screen should be refreshable again after a previous refresh completes."""
+        screen = self._make_screen()
+        coordinator = ScreenRefreshCoordinator()
+
+        await coordinator.refresh(screen)
+        await coordinator.refresh(screen)
+
+        assert screen.refresh_data.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exception_in_refresh_data_is_suppressed(self) -> None:
+        """Exceptions raised by refresh_data() should be suppressed."""
+        screen = self._make_screen(
+            refresh_data=AsyncMock(side_effect=RuntimeError("network error"))
+        )
+        coordinator = ScreenRefreshCoordinator()
+
+        await coordinator.refresh(screen)  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_ineligible_screen_is_skipped(self) -> None:
+        """A screen with auto_refresh_enabled=False should not be refreshed."""
+        screen = self._make_screen()
+        screen.auto_refresh_enabled = False
+        coordinator = ScreenRefreshCoordinator()
+
+        await coordinator.refresh(screen)
+
+        screen.refresh_data.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_always_runs(self) -> None:
+        """force_refresh() should run even if a refresh is already in progress."""
+        call_count = 0
+
+        async def slow_refresh() -> None:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+
+        screen = self._make_screen(refresh_data=slow_refresh)
+        coordinator = ScreenRefreshCoordinator()
+
+        await asyncio.gather(
+            coordinator.force_refresh(screen),
+            coordinator.force_refresh(screen),
+        )
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_blocks_auto_refresh(self) -> None:
+        """auto-refresh should be skipped while force_refresh() is in progress."""
+        call_count = 0
+
+        async def slow_refresh() -> None:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+
+        screen = self._make_screen(refresh_data=slow_refresh)
+        coordinator = ScreenRefreshCoordinator()
+
+        await asyncio.gather(
+            coordinator.force_refresh(screen),
+            coordinator.refresh(screen),
+        )
+
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_does_not_suppress_exceptions(self) -> None:
+        """force_refresh() should propagate exceptions from refresh_data()."""
+        screen = self._make_screen(
+            refresh_data=AsyncMock(side_effect=RuntimeError("network error"))
+        )
+        coordinator = ScreenRefreshCoordinator()
+
+        with pytest.raises(RuntimeError):
+            await coordinator.force_refresh(screen)


### PR DESCRIPTION
## PR Info

Closes #281

MadsciApp._auto_refresh_active_screen() called screen.refresh_data() on a 5-second interval with no guard against overlapping calls. If a refresh took longer than the interval, a second call would start while the first was still in-flight, causing concurrent mutation of screen data structures.

Introduced ScreenRefreshCoordinator (refresh_coordinator.py) to own all refresh coordination logic:
- refresh(): used by the auto-refresh timer; skips if a refresh is already in progress for the screen, suppresses exceptions so a slow network does not crash the TUI
- force_refresh(): used by action_refresh (manual 'r' key); always runs but registers with the coordinator to block concurrent auto-refresh while the manual refresh is in progress, propagates exceptions

MadsciApp._auto_refresh_active_screen() and action_refresh() now delegate entirely to the coordinator.

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
