### PR TITLE
feat(workcell): migrate scheduler config to Pydantic ImportString

### DIFF
--- a/src/madsci_common/madsci/common/types/workcell_types.py
+++ b/src/madsci_common/madsci/common/types/workcell_types.py
@@ -20,7 +20,7 @@ from madsci.common.types.node_types import Node
 from madsci.common.types.workflow_types import AliasChoices, Workflow
 from madsci.common.utils import new_ulid_str
 from madsci.common.validators import ulid_validator
-from pydantic import Field, computed_field
+from pydantic import Field, ImportString, computed_field
 from pydantic.functional_validators import field_validator
 from pydantic.networks import AnyUrl
 from pydantic_settings import SettingsConfigDict
@@ -275,11 +275,31 @@ class WorkcellManagerSettings(
         title="Cold Start Delay",
         description="How long the Workcell engine should sleep on startup",
     )
-    scheduler: str = Field(
-        default="madsci.workcell_manager.schedulers.default_scheduler",
-        title="scheduler",
-        description="Scheduler module that contains a Scheduler class that inherits from AbstractScheduler to use",
+    scheduler: ImportString = Field(
+        default="madsci.workcell_manager.schedulers.default_scheduler:Scheduler",
+        title="Scheduler",
+        description=(
+            "Scheduler class to use, as a 'module:ClassName' import path "
+            "(e.g. 'madsci.workcell_manager.schedulers.default_scheduler:Scheduler'). "
+            "Must inherit from AbstractScheduler."
+        ),
     )
+
+    @field_validator("scheduler", mode="before")
+    @classmethod
+    def _handle_legacy_scheduler_string(cls, v: object) -> object:
+        """Accept old bare-module strings and rewrite them to module:ClassName form."""
+        if isinstance(v, str) and ":" not in v:
+            warnings.warn(
+                f"Scheduler config '{v}' uses the legacy bare-module format. "
+                f"Use '{v}:Scheduler' instead. "
+                "Bare-module scheduler strings will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return f"{v}:Scheduler"
+        return v
+
     document_db_url: Optional[AnyUrl] = Field(
         default=AnyUrl("mongodb://localhost:27017"),
         title="Document Database URL",

--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
@@ -3,7 +3,6 @@ Engine Class and associated helpers and data
 """
 
 import concurrent
-import importlib
 import time
 from datetime import datetime
 from typing import Optional, Union
@@ -68,8 +67,7 @@ class Engine:
         self.workcell_info = state_handler.get_workcell_info()
         self.logger = EventClient(name=f"workcell.{self.workcell_info.name}")
         cancel_active_workflows(state_handler)
-        scheduler_module = importlib.import_module(self.workcell_settings.scheduler)
-        self.scheduler = scheduler_module.Scheduler(
+        self.scheduler = self.workcell_settings.scheduler(
             self.workcell_info, self.state_handler
         )
         self.data_client = data_client


### PR DESCRIPTION
## PR Info

Partially closes #340 (scheduler half; the \`event_handlers\` half is blocked on #312)

Replaces \`scheduler: str\` + \`importlib.import_module()\` with Pydantic's \`ImportString\` type in \`WorkcellManagerSettings\`, so misconfigured scheduler paths are caught at startup rather than when the engine first initializes.

The new preferred format is \`module:ClassName\` (e.g. \`madsci.workcell_manager.schedulers.default_scheduler:Scheduler\`), removing the implicit convention that the scheduler class must be named \`Scheduler\`. Old bare-module strings are still accepted for one release cycle and emit a \`DeprecationWarning\`. The now-unnecessary \`import importlib\` is removed from \`workcell_engine.py\` and the 3-line scheduler instantiation collapses to a single call.

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [ ] Created or updated documentation relevant to your change - I didn't add documentation because I felt it wasn't warranted for this change. I can add it if desired.
- [x] Created or updated unit tests relevant to your change