### PR TITLE
Add filelock runtime dependency to madsci-common

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:e6fa611ab50dd35c57bedd18fbeaec5a37c7eced79b57add49e52c382c9930fd"
+content_hash = "sha256:c02a6202de82b449bd768ed15e9a19da5a288f0e7f4a40f94adc9544faab889a"
 
 [[metadata.targets]]
 requires_python = ">=3.10.0"
@@ -2110,6 +2110,7 @@ dependencies = [
     "classy-fastapi",
     "click",
     "fastapi",
+    "filelock",
     "httpx",
     "multiprocess",
     "opentelemetry-api",

--- a/src/madsci_common/pyproject.toml
+++ b/src/madsci_common/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pymongo>=4.10.1",
     "psycopg2-binary>=2.9.0",
     "fastapi>=0.115.4",
+    "filelock>=3.12",
     "uvicorn[standard]>=0.32.0",
     "python-multipart>=0.0.17",
     "pydantic-extra-types>=2.10.2",


### PR DESCRIPTION
## Summary
- Add `filelock>=3.12` to `madsci.common` runtime dependencies because `madsci.common.registry.local_registry` imports `FileLock` and `Timeout` at module import time.
- Keep `pdm.lock` in sync for the editable `madsci-common` package entry.

Fixes #345.

## Verification
- Reproduced the published-package failure in a clean venv with `madsci.common==0.8.0`: `ModuleNotFoundError: No module named 'filelock'` when importing `madsci.common.registry.local_registry`.\n- Installed local `./src/madsci_common` in a clean venv and confirmed `filelock` is installed as `Required-by: madsci.common`, the import succeeds, and package metadata includes a filelock requirement.\n- `python -m pytest src/madsci_common/tests/test_registry/test_local_registry.py -q` -> 16 passed.\n- `python -m pytest src/madsci_common/tests/test_registry_resolution.py -q` with editable `madsci_common` + `madsci_client` -> 16 passed.\n- `pdm lock --check` passed with PDM 2.27.0.\n- `git diff --check` passed.