### PR TITLE
Fix for Issue #343, madsci common import of psycopg2 not needed, bloc…

### DIFF
--- a/src/madsci_common/pyproject.toml
+++ b/src/madsci_common/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "requests>=2.32.3",
     "pymongo>=4.10.1",
-    "psycopg2-binary>=2.9.0",
     "fastapi>=0.115.4",
     "filelock>=3.12",
     "uvicorn[standard]>=0.32.0",


### PR DESCRIPTION

## PR Info

Fixes Issue #343 .

Removes the psycopg2-binary dependency in `madsci.common `as not directly referenced in manager. 32-bit Python installs no longer blocked by dependency.

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
