### PR TITLE
Fix for Issue #289: Malformed Rate Limit Headers.

### DIFF
--- a/src/madsci_common/madsci/common/utils.py
+++ b/src/madsci_common/madsci/common/utils.py
@@ -555,20 +555,27 @@ class RateLimitTracker:
         Args:
             headers: HTTP response headers dictionary
         """
-        with self._lock:
-            # Parse long window rate limit headers
-            if "X-RateLimit-Limit" in headers:
-                self.limit = int(headers["X-RateLimit-Limit"])
-            if "X-RateLimit-Remaining" in headers:
-                self.remaining = int(headers["X-RateLimit-Remaining"])
-            if "X-RateLimit-Reset" in headers:
-                self.reset = int(headers["X-RateLimit-Reset"])
+        header_attr_map = (
+            ("X-RateLimit-Limit", "limit"),
+            ("X-RateLimit-Remaining", "remaining"),
+            ("X-RateLimit-Reset", "reset"),
+            ("X-RateLimit-Burst-Limit", "burst_limit"),
+            ("X-RateLimit-Burst-Remaining", "burst_remaining"),
+        )
 
-            # Parse burst window rate limit headers if present
-            if "X-RateLimit-Burst-Limit" in headers:
-                self.burst_limit = int(headers["X-RateLimit-Burst-Limit"])
-            if "X-RateLimit-Burst-Remaining" in headers:
-                self.burst_remaining = int(headers["X-RateLimit-Burst-Remaining"])
+        with self._lock:
+            for header_name, attr in header_attr_map:
+                if header_name not in headers:
+                    continue
+                raw = headers[header_name]
+                try:
+                    setattr(self, attr, int(raw))
+                except (ValueError, TypeError):
+                    logger.debug(
+                        "Ignoring unparseable rate limit header %s=%r",
+                        header_name,
+                        raw,
+                    )
 
             # Log warnings if approaching limits
             self._check_and_warn()

--- a/src/madsci_common/tests/test_utils.py
+++ b/src/madsci_common/tests/test_utils.py
@@ -496,6 +496,34 @@ class TestRateLimitTracker:
         assert tracker.burst_limit == 10
         assert tracker.burst_remaining == 5
 
+    def test_update_from_headers_ignores_malformed_values(self):
+        """Malformed rate limit headers must not raise ValueError."""
+        tracker = RateLimitTracker()
+        # First seed valid values so we can confirm bad values do not clobber them.
+        tracker.update_from_headers(
+            {
+                "X-RateLimit-Limit": "100",
+                "X-RateLimit-Remaining": "75",
+                "X-RateLimit-Reset": str(int(time.time()) + 60),
+            }
+        )
+
+        malformed = {
+            "X-RateLimit-Limit": "unknown",
+            "X-RateLimit-Remaining": "",
+            "X-RateLimit-Reset": "not-a-number",
+            "X-RateLimit-Burst-Limit": "nope",
+            "X-RateLimit-Burst-Remaining": "",
+        }
+        # Should not raise; previous valid state must be preserved.
+        tracker.update_from_headers(malformed)
+
+        assert tracker.limit == 100
+        assert tracker.remaining == 75
+        assert tracker.reset is not None
+        assert tracker.burst_limit is None
+        assert tracker.burst_remaining is None
+
     def test_get_status(self):
         """Test getting rate limit status."""
         tracker = RateLimitTracker()


### PR DESCRIPTION
Fix authored by @SAY-5.
## PR Info

Closes #289.

Previously, `RateLimitTracker.update_from_headers()` called `int()` on `X-RateLimit-*` values without error handling. Servers occasionally send non-numeric values (e.g. `'unknown'`, empty strings), which raised ValueError and bubbled all the way up, failing an otherwise successful HTTP request.

Convert each header through a try/except (`ValueError`, `TypeError`) and log at debug level when a value is unparseable, preserving any previously-recorded valid state.

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
