### PR TITLE
Fix for Issue #284: CLI output can now handle nested Pydantic models in dict values

### DIFF
--- a/src/madsci_client/madsci/client/cli/utils/output.py
+++ b/src/madsci_client/madsci/client/cli/utils/output.py
@@ -110,6 +110,8 @@ def _serialize(data: Any) -> Any:
         return data.model_dump(mode="json")
     if isinstance(data, list):
         return [_serialize(item) for item in data]
+    if isinstance(data, dict):
+        return {k: _serialize(v) for k, v in data.items()}
     return data
 
 

--- a/src/madsci_client/tests/cli/test_output_enhanced.py
+++ b/src/madsci_client/tests/cli/test_output_enhanced.py
@@ -118,7 +118,7 @@ class SampleModel(BaseModel):
     """A minimal Pydantic model for testing."""
 
     name: str = "test"
-    value: int = 42
+    value: int | dict = 42
 
 
 class TestOutputResultEnhanced:
@@ -227,3 +227,23 @@ class TestOutputResultEnhanced:
         text = _get_output(console)
         # Should print the whole dict as string
         assert "a" in text
+
+    def test_json_mode_with_dict(self) -> None:
+        console = _capture_console()
+        output_result(
+            console, data={"model": SampleModel(name="dict", value=42)}, format="json"
+        )
+        text = _get_output(console)
+        assert '"dict"' in text
+        assert '"model"' in text
+        assert "42" in text
+
+    def test_yaml_mode_with_dict(self) -> None:
+        console = _capture_console()
+        output_result(
+            console, data={"model": SampleModel(name="dict", value=42)}, format="yaml"
+        )
+        text = _get_output(console)
+        assert "name: dict" in text
+        assert "model:" in text
+        assert "42" in text


### PR DESCRIPTION
Closes Issue #284 

CLI output can now correctly serialize nested Pydantic models contained as dict values in JSON and YAML formats. Relevant unit tests added to confirm correct serialization for both formats.

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
