### PR TITLE
Fix for Issue #277: Fix  treated as False across all clients.

### DIFF
--- a/src/madsci_client/madsci/client/data_client.py
+++ b/src/madsci_client/madsci/client/data_client.py
@@ -110,7 +110,7 @@ class DataClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.data_server_url}datapoint/{datapoint_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return DataPoint.discriminate(response.json())
@@ -250,7 +250,7 @@ class DataClient(DualModeClientMixin):
             "GET",
             f"{self.data_server_url}datapoints",
             params={"number": number},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [
@@ -276,7 +276,7 @@ class DataClient(DualModeClientMixin):
             "POST",
             f"{self.data_server_url}datapoints/query",
             json=selector,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return {
@@ -582,7 +582,7 @@ class DataClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.data_server_url}datapoint/{datapoint_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return DataPoint.discriminate(response.json())
@@ -606,7 +606,7 @@ class DataClient(DualModeClientMixin):
             "GET",
             f"{self.data_server_url}datapoints",
             params={"number": number},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [
@@ -632,7 +632,7 @@ class DataClient(DualModeClientMixin):
             "POST",
             f"{self.data_server_url}datapoints/query",
             json=selector,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return {

--- a/src/madsci_client/madsci/client/event_client.py
+++ b/src/madsci_client/madsci/client/event_client.py
@@ -737,7 +737,7 @@ class EventClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.event_server}event/{event_id}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             if not response.is_success:
                 response.raise_for_status()
@@ -765,7 +765,7 @@ class EventClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.event_server}events",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
                 params={"number": number, "level": level},
             )
             if not response.is_success:
@@ -883,7 +883,7 @@ class EventClient(DualModeClientMixin):
             response = self._request(
                 "POST",
                 f"{self.event_server}events/query",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
                 params={"selector": selector},
             )
             if not response.is_success:
@@ -1265,7 +1265,7 @@ class EventClient(DualModeClientMixin):
             response = await self._async_request(
                 "GET",
                 f"{self.event_server}event/{event_id}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             if not response.is_success:
                 response.raise_for_status()
@@ -1291,7 +1291,7 @@ class EventClient(DualModeClientMixin):
             response = await self._async_request(
                 "GET",
                 f"{self.event_server}events",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
                 params={"number": number, "level": level},
             )
             if not response.is_success:
@@ -1322,7 +1322,7 @@ class EventClient(DualModeClientMixin):
             response = await self._async_request(
                 "POST",
                 f"{self.event_server}events/query",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
                 params={"selector": selector},
             )
             if not response.is_success:

--- a/src/madsci_client/madsci/client/experiment_client.py
+++ b/src/madsci_client/madsci/client/experiment_client.py
@@ -74,7 +74,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.experiment_server_url}experiment/{experiment_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -93,7 +93,7 @@ class ExperimentClient(DualModeClientMixin):
             "GET",
             f"{self.experiment_server_url}experiments",
             params={"number": number},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Experiment.model_validate(experiment) for experiment in response.json()]
@@ -122,7 +122,7 @@ class ExperimentClient(DualModeClientMixin):
                 run_name=run_name,
                 run_description=run_description,
             ).model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -145,7 +145,7 @@ class ExperimentClient(DualModeClientMixin):
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/end",
             params={"status": status},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -163,7 +163,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/continue",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -181,7 +181,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/pause",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -199,7 +199,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/cancel",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -218,7 +218,7 @@ class ExperimentClient(DualModeClientMixin):
             "POST",
             f"{self.experiment_server_url}campaign",
             json=campaign.model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ExperimentalCampaign.model_validate(response.json())
@@ -236,7 +236,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.experiment_server_url}campaign/{campaign_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ExperimentalCampaign.model_validate(response.json())
@@ -253,7 +253,7 @@ class ExperimentClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.experiment_server_url}campaigns",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [ExperimentalCampaign.model_validate(c) for c in response.json()]
@@ -275,7 +275,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.experiment_server_url}experiment/{experiment_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -294,7 +294,7 @@ class ExperimentClient(DualModeClientMixin):
             "GET",
             f"{self.experiment_server_url}experiments",
             params={"number": number},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Experiment.model_validate(experiment) for experiment in response.json()]
@@ -323,7 +323,7 @@ class ExperimentClient(DualModeClientMixin):
                 run_name=run_name,
                 run_description=run_description,
             ).model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -346,7 +346,7 @@ class ExperimentClient(DualModeClientMixin):
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/end",
             params={"status": status},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -364,7 +364,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/continue",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -382,7 +382,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/pause",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -400,7 +400,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.experiment_server_url}experiment/{experiment_id}/cancel",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Experiment.model_validate(response.json())
@@ -419,7 +419,7 @@ class ExperimentClient(DualModeClientMixin):
             "POST",
             f"{self.experiment_server_url}campaign",
             json=campaign.model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ExperimentalCampaign.model_validate(response.json())
@@ -437,7 +437,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.experiment_server_url}campaign/{campaign_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ExperimentalCampaign.model_validate(response.json())
@@ -454,7 +454,7 @@ class ExperimentClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.experiment_server_url}campaigns",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [ExperimentalCampaign.model_validate(c) for c in response.json()]

--- a/src/madsci_client/madsci/client/lab_client.py
+++ b/src/madsci_client/madsci/client/lab_client.py
@@ -70,7 +70,7 @@ class LabClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.lab_server_url}context",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return MadsciContext.model_validate(response.json())
@@ -85,7 +85,7 @@ class LabClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.lab_server_url}health",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ManagerHealth.model_validate(response.json())
@@ -100,7 +100,7 @@ class LabClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.lab_server_url}lab_health",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LabHealth.model_validate(response.json())
@@ -121,7 +121,7 @@ class LabClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.lab_server_url}context",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return MadsciContext.model_validate(response.json())
@@ -138,7 +138,7 @@ class LabClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.lab_server_url}health",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ManagerHealth.model_validate(response.json())
@@ -153,7 +153,7 @@ class LabClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.lab_server_url}lab_health",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LabHealth.model_validate(response.json())

--- a/src/madsci_client/madsci/client/location_client.py
+++ b/src/madsci_client/madsci/client/location_client.py
@@ -192,7 +192,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}locations",
             params=params or None,
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Location.model_validate(loc) for loc in response.json()]
@@ -222,7 +222,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             params={"location_id": location_id},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -252,7 +252,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             params={"name": location_name},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -282,7 +282,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             json=location.model_dump(),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -352,7 +352,7 @@ class LocationClient(DualModeClientMixin):
                 f"{self.location_server_url}location/init",
                 json=location.model_dump(mode="json"),
                 headers=self._get_headers(),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             return Location.model_validate(response.json())
@@ -416,7 +416,7 @@ class LocationClient(DualModeClientMixin):
             json=[loc.model_dump() for loc in locations],
             params={"overwrite": overwrite},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationImportResult.model_validate(response.json())
@@ -441,7 +441,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}locations/export",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Location.model_validate(loc) for loc in response.json()]
@@ -457,7 +457,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}representation_templates",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [
@@ -473,7 +473,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}representation_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationRepresentationTemplate.model_validate(response.json())
@@ -490,7 +490,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}representation_template",
             json=template.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationRepresentationTemplate.model_validate(response.json())
@@ -535,7 +535,7 @@ class LocationClient(DualModeClientMixin):
                 f"{self.location_server_url}representation_template/init",
                 json=template.model_dump(mode="json"),
                 headers=self._get_headers(),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             return LocationRepresentationTemplate.model_validate(response.json())
@@ -553,7 +553,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}representation_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -569,7 +569,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location_templates",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [LocationTemplate.model_validate(t) for t in response.json()]
@@ -583,7 +583,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationTemplate.model_validate(response.json())
@@ -600,7 +600,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location_template",
             json=template.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationTemplate.model_validate(response.json())
@@ -642,7 +642,7 @@ class LocationClient(DualModeClientMixin):
                 f"{self.location_server_url}location_template/init",
                 json=template.model_dump(mode="json"),
                 headers=self._get_headers(),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             return LocationTemplate.model_validate(response.json())
@@ -660,7 +660,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -694,7 +694,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/from_template",
             json=request.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -723,7 +723,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -761,7 +761,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/{location_name}/set_representation/{node_name}",
             json=representation,
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -795,7 +795,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}/remove_representation/{node_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -827,7 +827,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/{location_name}/attach_resource",
             params={"resource_id": resource_id},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -856,7 +856,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}/detach_resource",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -884,7 +884,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}transfer/graph",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -914,7 +914,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}transfer/graph/detailed",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return TransferGraphDetailedResponse.model_validate(response.json())
@@ -959,7 +959,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}transfer/plan",
             params=params,
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return WorkflowDefinition.model_validate(response.json())
@@ -988,7 +988,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location/{location_name}/resources",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ResourceHierarchy.model_validate(response.json())
@@ -1006,7 +1006,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}locations",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Location.model_validate(loc) for loc in response.json()]
@@ -1021,7 +1021,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             params={"location_id": location_id},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1036,7 +1036,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             params={"name": location_name},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1051,7 +1051,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location",
             json=location.model_dump(),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1065,7 +1065,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}locations/export",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Location.model_validate(loc) for loc in response.json()]
@@ -1079,7 +1079,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -1098,7 +1098,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/{location_name}/set_representation/{node_name}",
             json=representation,
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1115,7 +1115,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}/remove_representation/{node_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1130,7 +1130,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/{location_name}/attach_resource",
             params={"resource_id": resource_id},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1144,7 +1144,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location/{location_name}/detach_resource",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1158,7 +1158,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}transfer/graph",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -1183,7 +1183,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}transfer/plan",
             params=params,
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return WorkflowDefinition.model_validate(response.json())
@@ -1197,7 +1197,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location/{location_name}/resources",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ResourceHierarchy.model_validate(response.json())
@@ -1213,7 +1213,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}representation_templates",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [
@@ -1229,7 +1229,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}representation_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationRepresentationTemplate.model_validate(response.json())
@@ -1246,7 +1246,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}representation_template",
             json=template.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationRepresentationTemplate.model_validate(response.json())
@@ -1260,7 +1260,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}representation_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -1276,7 +1276,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location_templates",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [LocationTemplate.model_validate(t) for t in response.json()]
@@ -1290,7 +1290,7 @@ class LocationClient(DualModeClientMixin):
             "GET",
             f"{self.location_server_url}location_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationTemplate.model_validate(response.json())
@@ -1307,7 +1307,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location_template",
             json=template.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationTemplate.model_validate(response.json())
@@ -1321,7 +1321,7 @@ class LocationClient(DualModeClientMixin):
             "DELETE",
             f"{self.location_server_url}location_template/{template_name}",
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -1355,7 +1355,7 @@ class LocationClient(DualModeClientMixin):
             f"{self.location_server_url}location/from_template",
             json=request.model_dump(mode="json"),
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Location.model_validate(response.json())
@@ -1414,7 +1414,7 @@ class LocationClient(DualModeClientMixin):
             json=[loc.model_dump() for loc in locations],
             params={"overwrite": overwrite},
             headers=self._get_headers(),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return LocationImportResult.model_validate(response.json())

--- a/src/madsci_client/madsci/client/node/rest_node_client.py
+++ b/src/madsci_client/madsci/client/node/rest_node_client.py
@@ -309,7 +309,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = self._request(
             "GET",
             f"{self.url}/action/{action_name}/{action_id}/status",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         rest_response.raise_for_status()
         return ActionStatus(rest_response.json())
@@ -451,7 +451,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = self._request(
             "GET",
             f"{self.url}/action/{action_name}/{action_id}/result",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         try:
             rest_response.raise_for_status()
@@ -518,7 +518,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             "GET",
             f"{self.url}/action",
             params={"action_id": action_id},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -536,7 +536,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = self._request(
             "GET",
             f"{self.url}/action/{action_id}/status",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         rest_response.raise_for_status()
         return ActionStatus(rest_response.json())
@@ -557,7 +557,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = self._request(
             "GET",
             f"{self.url}/action/{action_id}/result",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         rest_response.raise_for_status()
 
@@ -645,7 +645,9 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             timeout: Optional timeout override in seconds. If None, uses config.timeout_default.
         """
         response = self._request(
-            "GET", f"{self.url}/status", timeout=timeout or self.config.timeout_default
+            "GET",
+            f"{self.url}/status",
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return NodeStatus.model_validate(response.json())
@@ -658,7 +660,9 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             timeout: Optional timeout override in seconds. If None, uses config.timeout_default.
         """
         response = self._request(
-            "GET", f"{self.url}/state", timeout=timeout or self.config.timeout_default
+            "GET",
+            f"{self.url}/state",
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -671,7 +675,9 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             timeout: Optional timeout override in seconds. If None, uses config.timeout_default.
         """
         response = self._request(
-            "GET", f"{self.url}/info", timeout=timeout or self.config.timeout_default
+            "GET",
+            f"{self.url}/info",
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return NodeInfo.model_validate(response.json())
@@ -708,7 +714,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = self._request(
             "POST",
             f"{self.url}/admin/{admin_command}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return AdminCommandResponse.model_validate(response.json())
@@ -728,7 +734,9 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             timeout: Optional timeout override in seconds. If None, uses config.timeout_default.
         """
         response = self._request(
-            "GET", f"{self.url}/log", timeout=timeout or self.config.timeout_default
+            "GET",
+            f"{self.url}/log",
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -742,7 +750,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = await self._async_request(
             "GET",
             f"{self.url}/status",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return NodeStatus.model_validate(response.json())
@@ -752,7 +760,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = await self._async_request(
             "GET",
             f"{self.url}/state",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -762,7 +770,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = await self._async_request(
             "GET",
             f"{self.url}/info",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return NodeInfo.model_validate(response.json())
@@ -787,7 +795,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = await self._async_request(
             "POST",
             f"{self.url}/admin/{admin_command}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return AdminCommandResponse.model_validate(response.json())
@@ -800,7 +808,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
             "GET",
             f"{self.url}/action",
             params={"action_id": action_id},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -810,7 +818,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         response = await self._async_request(
             "GET",
             f"{self.url}/log",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -940,7 +948,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = await self._async_request(
             "GET",
             f"{self.url}/action/{action_name}/{action_id}/result",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         try:
             rest_response.raise_for_status()
@@ -983,7 +991,7 @@ class RestNodeClient(DualModeClientMixin, AbstractNodeClient):
         rest_response = await self._async_request(
             "GET",
             f"{self.url}/action/{action_id}/result",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         rest_response.raise_for_status()
 

--- a/src/madsci_client/madsci/client/resource_client.py
+++ b/src/madsci_client/madsci/client/resource_client.py
@@ -318,7 +318,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/add",
                 json=resource.model_dump(mode="json"),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -351,7 +351,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/init",
                 json=resource_definition.model_dump(mode="json"),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
 
@@ -388,7 +388,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/add_or_update",
                 json=resource.model_dump(mode="json"),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -419,7 +419,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/update",
                 json=resource.model_dump(mode="json"),
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -454,7 +454,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}resource/{resource_id}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -516,7 +516,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/query",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             response_json = response.json()
@@ -559,7 +559,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "DELETE",
                 f"{self.resource_server_url}resource/{resource}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -614,7 +614,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}history/query",
                 json=query,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
         else:
@@ -643,7 +643,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "POST",
                 f"{self.resource_server_url}history/{resource_id}/restore",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -692,7 +692,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/push",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -728,7 +728,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/pop",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             result = response.json()
@@ -778,7 +778,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/child/set",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -819,7 +819,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/child/remove",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -857,7 +857,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/quantity",
                 params={"quantity": quantity},
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -894,7 +894,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/quantity/change_by",
                 params={"amount": amount},
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -932,7 +932,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/quantity/increase",
                 params={"amount": amount},
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -970,7 +970,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/quantity/decrease",
                 params={"amount": amount},
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1008,7 +1008,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/capacity",
                 params={"capacity": capacity},
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1041,7 +1041,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "DELETE",
                 f"{self.resource_server_url}resource/{resource_id}/capacity",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1074,7 +1074,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/empty",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1111,7 +1111,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "POST",
                 f"{self.resource_server_url}resource/{resource_id}/fill",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1266,7 +1266,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}template/create",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             template = Resource.discriminate(response.json())
@@ -1306,7 +1306,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}template/{template_name}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             if response.status_code == 404:
                 return None
@@ -1352,14 +1352,14 @@ class ResourceClient(DualModeClientMixin):
                     "POST",
                     f"{self.resource_server_url}templates/query",
                     json=payload,
-                    timeout=timeout or self.config.timeout_default,
+                    timeout=self.config.timeout_default if timeout is None else timeout,
                 )
             else:
                 # Use query_all endpoint for no filtering
                 response = self._request(
                     "GET",
                     f"{self.resource_server_url}templates/query_all",
-                    timeout=timeout or self.config.timeout_default,
+                    timeout=self.config.timeout_default if timeout is None else timeout,
                 )
 
             response.raise_for_status()
@@ -1401,7 +1401,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}template/{template_name}/info",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             if response.status_code == 404:
                 return None
@@ -1443,7 +1443,7 @@ class ResourceClient(DualModeClientMixin):
                 "PUT",
                 f"{self.resource_server_url}template/{template_name}",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             template = Resource.discriminate(response.json())
@@ -1477,7 +1477,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "DELETE",
                 f"{self.resource_server_url}template/{template_name}",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             if response.status_code == 404:
                 return False
@@ -1530,7 +1530,7 @@ class ResourceClient(DualModeClientMixin):
                 "POST",
                 f"{self.resource_server_url}template/{template_name}/create_resource",
                 json=payload,
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             resource = Resource.discriminate(response.json())
@@ -1581,7 +1581,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}templates/categories",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             return response.json()
@@ -1627,7 +1627,7 @@ class ResourceClient(DualModeClientMixin):
                     "lock_duration": lock_duration,
                     "client_id": self._client_id,
                 },
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             if response.status_code == 200 and response.json():
@@ -1719,7 +1719,7 @@ class ResourceClient(DualModeClientMixin):
                     "DELETE",
                     f"{self.resource_server_url}resource/{resource_id}/unlock",
                     params={"client_id": self._client_id} if self._client_id else {},
-                    timeout=timeout or self.config.timeout_default,
+                    timeout=self.config.timeout_default if timeout is None else timeout,
                 )
                 response.raise_for_status()
                 if response.status_code == 200 and response.json():
@@ -1820,7 +1820,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}resource/{resource_id}/check_lock",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             result = response.json()
@@ -2053,7 +2053,7 @@ class ResourceClient(DualModeClientMixin):
             response = self._request(
                 "GET",
                 f"{self.resource_server_url}resource/{resource_id}/hierarchy",
-                timeout=timeout or self.config.timeout_default,
+                timeout=self.config.timeout_default if timeout is None else timeout,
             )
             response.raise_for_status()
             return ResourceHierarchy.model_validate(response.json())
@@ -2128,7 +2128,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.resource_server_url}resource/{resource_id}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2180,7 +2180,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}resource/query",
             json=payload,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -2210,7 +2210,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}resource/add",
             json=resource.model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2235,7 +2235,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}resource/update",
             json=resource.model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2260,7 +2260,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "DELETE",
             f"{self.resource_server_url}resource/{resource}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2282,7 +2282,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.resource_server_url}templates/query_all",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         templates = [Resource.discriminate(template) for template in response.json()]
@@ -2308,7 +2308,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.resource_server_url}template/{template_name}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         if response.status_code == 404:
             return None
@@ -2353,7 +2353,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}template/{template_name}/create_resource",
             json=payload,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2376,7 +2376,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.resource_server_url}resource/{resource_id}/hierarchy",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return ResourceHierarchy.model_validate(response.json())
@@ -2406,7 +2406,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}resource/{resource_id}/quantity",
             params={"quantity": quantity},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2438,7 +2438,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}resource/{resource_id}/quantity/change_by",
             params={"amount": amount},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())
@@ -2467,7 +2467,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.resource_server_url}resource/{resource_id}/check_lock",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = response.json()
@@ -2505,7 +2505,7 @@ class ResourceClient(DualModeClientMixin):
                 "lock_duration": lock_duration,
                 "client_id": self._client_id,
             },
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         if response.status_code == 200 and response.json():
@@ -2543,7 +2543,7 @@ class ResourceClient(DualModeClientMixin):
             "DELETE",
             f"{self.resource_server_url}resource/{resource_id}/unlock",
             params={"client_id": self._client_id} if self._client_id else {},
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         if response.status_code == 200 and response.json():
@@ -2595,7 +2595,7 @@ class ResourceClient(DualModeClientMixin):
             "POST",
             f"{self.resource_server_url}history/query",
             json=query,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return response.json()
@@ -2619,7 +2619,7 @@ class ResourceClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.resource_server_url}history/{resource_id}/restore",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         result = Resource.discriminate(response.json())

--- a/src/madsci_client/madsci/client/workcell_client.py
+++ b/src/madsci_client/madsci/client/workcell_client.py
@@ -119,7 +119,9 @@ class WorkcellClient(DualModeClientMixin):
         """
         url = f"{self.workcell_server_url}workflow/{workflow_id}"
         response = self._request(
-            "GET", url, timeout=timeout or self.config.timeout_default
+            "GET",
+            url,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
 
         if not response.is_success and response.content:
@@ -152,7 +154,9 @@ class WorkcellClient(DualModeClientMixin):
         """
         url = f"{self.workcell_server_url}workflow_definition/{workflow_definition_id}"
         response = self._request(
-            "GET", url, timeout=timeout or self.config.timeout_default
+            "GET",
+            url,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         if not response.is_success and response.content:
             self.logger.error(
@@ -196,7 +200,7 @@ class WorkcellClient(DualModeClientMixin):
             "POST",
             url,
             json=workflow_definition.model_dump(mode="json"),
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
 
         if not response.is_success and response.content:
@@ -443,7 +447,7 @@ class WorkcellClient(DualModeClientMixin):
                 "workflow_id": workflow_id,
                 "index": index,
             },
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         if await_completion:
@@ -492,7 +496,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "POST",
             url,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         new_workflow = Workflow.model_validate(response.json())
@@ -656,7 +660,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.workcell_server_url}nodes",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return {
@@ -682,7 +686,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.workcell_server_url}node/{node_name}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Node.model_validate(response.json())
@@ -725,7 +729,7 @@ class WorkcellClient(DualModeClientMixin):
                 "node_description": node_description,
                 "permanent": permanent,
             },
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Node.model_validate(response.json())
@@ -812,7 +816,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.workcell_server_url}workflows/queue",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Workflow.model_validate(wf) for wf in response.json()]
@@ -834,7 +838,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "GET",
             f"{self.workcell_server_url}state",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return WorkcellState.model_validate(response.json())
@@ -860,7 +864,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/pause",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -886,7 +890,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/resume",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -912,7 +916,7 @@ class WorkcellClient(DualModeClientMixin):
         response = self._request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/cancel",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -927,7 +931,9 @@ class WorkcellClient(DualModeClientMixin):
         """Check the status of a workflow using its ID asynchronously."""
         url = f"{self.workcell_server_url}workflow/{workflow_id}"
         response = await self._async_request(
-            "GET", url, timeout=timeout or self.config.timeout_default
+            "GET",
+            url,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         if not response.is_success and response.content:
             self.logger.error(
@@ -944,7 +950,9 @@ class WorkcellClient(DualModeClientMixin):
         """Get the definition of a workflow asynchronously."""
         url = f"{self.workcell_server_url}workflow_definition/{workflow_definition_id}"
         response = await self._async_request(
-            "GET", url, timeout=timeout or self.config.timeout_default
+            "GET",
+            url,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         if not response.is_success and response.content:
             self.logger.error(
@@ -960,7 +968,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.workcell_server_url}nodes",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return {
@@ -974,7 +982,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.workcell_server_url}node/{node_name}",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Node.model_validate(response.json())
@@ -1025,7 +1033,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.workcell_server_url}workflows/queue",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return [Workflow.model_validate(wf) for wf in response.json()]
@@ -1037,7 +1045,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "GET",
             f"{self.workcell_server_url}state",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return WorkcellState.model_validate(response.json())
@@ -1049,7 +1057,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/pause",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -1061,7 +1069,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/resume",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -1073,7 +1081,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             f"{self.workcell_server_url}workflow/{workflow_id}/cancel",
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -1107,7 +1115,7 @@ class WorkcellClient(DualModeClientMixin):
             "POST",
             url,
             params=params,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())
@@ -1136,7 +1144,7 @@ class WorkcellClient(DualModeClientMixin):
         response = await self._async_request(
             "POST",
             url,
-            timeout=timeout or self.config.timeout_default,
+            timeout=self.config.timeout_default if timeout is None else timeout,
         )
         response.raise_for_status()
         return Workflow.model_validate(response.json())


### PR DESCRIPTION
## PR Info

Fixes Issue #277 

Removes about ~150+ instances of `timeout=self.config.timeout_default if timeout is None else timeout` with `timeout=timeout or self.config.timeout_default` across client files. `0.0` now correctly sets the wait time to 0 seconds instead of False (Default config wait time).

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
