### PR TITLE
added error logging to step failure

### DIFF
--- a/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
+++ b/src/madsci_workcell_manager/madsci/workcell_manager/workcell_engine.py
@@ -509,6 +509,14 @@ class Engine:
             elif step.status == ActionStatus.FAILED:
                 wf.status.failed = True
                 wf.end_time = datetime.now()
+                self.logger.error(
+                                    f"Workflow step failed, errors: {str(step.result.errors)}",
+                                    event_type=EventType.WORKFLOW_STEP_FAILED,
+                                    workflow_id=workflow_id,
+                                    step_id=step.step_id,
+                                    step_action=step.action,
+                                    step_node=step.node
+                                )
             elif step.status == ActionStatus.CANCELLED:
                 self.logger.debug(
                     "Step cancelled, setting workflow status to cancelled",


### PR DESCRIPTION
## PR Info

Previously, MADSci workcell manager did not send an event when a step failed. This relied on the node to throw an error, which wasn't reliably implemented. I have changed the default behavior to throw an error when a step fails to ensure a notification is send regardless of the node implementation. 

## Developer Checklists

I have:

- [x] Run Pre-commit and Unit Tests, and ensured that they pass
- [x] Created or updated documentation relevant to your change
- [x] Created or updated unit tests relevant to your change
